### PR TITLE
Maintenance: 1-based menus, quizX filenames, --crn flag, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,17 @@ subdirectories have been created.
 ### Usage
 
 ```bash
-source set_env.sh                        # set Canvas environment variables (once per terminal session)
-python canvigator.py <task>              # run a task
-python canvigator.py --dry-run <task>    # preview bonus changes without modifying Canvas
+source set_env.sh                            # set Canvas environment variables (once per terminal session)
+python canvigator.py <task>                  # run a task (prompts for course selection)
+python canvigator.py --crn <CRN> <task>      # select course by CRN (last 5 digits of course code)
+python canvigator.py --dry-run <task>        # preview bonus changes without modifying Canvas
 ```
 
-Available tasks: `activity`, `pair`, `award-bonus`, `re-award-bonus`, `all-subs`
+The `--crn` option selects a course by its CRN (the last 5 digits of the Canvas
+course code), bypassing the interactive course selection prompt. This is useful
+for automated/scheduled runs, e.g. `python canvigator.py --crn 12345 activity`.
+
+Available tasks: `activity`, `pair`, `auto-award-bonus`, `award-bonus`, `re-award-bonus`, `all-subs`
 
 All tasks begin by prompting you to select a course. Output files are written to
 `data/<course>/` and `figures/<course>/`, where `<course>` is derived from the
@@ -134,6 +139,37 @@ required format (columns: `name`, `id`, `present` where 1 = present).
 1. Mark which students are present in your `present_*.csv` file.
 2. Run `python canvigator.py pair` and select the course, quiz, and presence CSV when prompted.
 3. Open the generated `*_pairing_via_med_*.csv` and share pairings with the class.
+
+---
+
+#### `auto-award-bonus` — Automatically detect partners and award bonus points
+
+Automatically detects student partner groups by comparing first-attempt
+per-question scores and answer timestamps from a prior `all-subs` run. Students
+whose first attempts show a high fraction of matching scores (default ≥ 80%)
+and closely timed answers (default within 10 seconds on ≥ 80% of questions)
+are grouped as partners. Groups larger than 3 are flagged for manual review.
+After detection, bonus fudge points are awarded on their Canvas submissions.
+
+**Before running:** the `all-subs` task must have been run first for the same
+quiz so that the events and per-question submission CSVs exist.
+
+| | Files |
+|---|---|
+| **Input** | `data/<course>/<quiz>_<id>_all_subs_and_events_YYYYMMDD.csv` (from `all-subs`) |
+| | `data/<course>/<quiz>_<id>_all_subs_by_question_YYYYMMDD.csv` (from `all-subs`) |
+| **Output** | `data/<course>/<quiz>_<id>_detected_partners_YYYYMMDD.csv` — detected partner groups |
+| | `data/<course>/<quiz>_<id>_scores_w_bonus_YYYYMMDD.csv` — scores with bonus column |
+| **Canvas side-effect** | Sets `fudge_points` on qualifying quiz submissions (skipped in `--dry-run` mode) |
+
+Use `--dry-run` to preview which students would receive bonus points without
+modifying anything in Canvas. In dry-run mode the scores CSV is named
+`*_scores_w_bonus_dryrun_*.csv`.
+
+**Typical workflow:**
+1. Run `python canvigator.py all-subs` to export submission data for all quizzes.
+2. Run `python canvigator.py [--dry-run] auto-award-bonus` and select the course, quiz, and date when prompted.
+3. Review the `*_detected_partners_*.csv` to verify the detected groups.
 
 ---
 

--- a/canvigator.py
+++ b/canvigator.py
@@ -8,15 +8,29 @@ dry_run = '--dry-run' in args
 if dry_run:
     args.remove('--dry-run')
 
+crn = None
+if '--crn' in args:
+    crn_idx = args.index('--crn')
+    if crn_idx + 1 >= len(args):
+        print("Error: --crn requires a 5-digit CRN value")
+        sys.exit(1)
+    crn = args[crn_idx + 1]
+    if not crn.isdigit() or len(crn) != 5:
+        print(f"Error: CRN must be exactly 5 digits, got '{crn}'")
+        sys.exit(1)
+    args.pop(crn_idx)  # remove '--crn'
+    args.pop(crn_idx)  # remove the CRN value
+
 if len(args) < 1:
-    print(f"Usage: canvigator.py [--dry-run] {' | '.join(tasks)}")
+    print(f"Usage: canvigator.py [--dry-run] [--crn <CRN>] {' | '.join(tasks)}")
     sys.exit(1)
 
 task = args[0]
 
 if task in ("help", "--help"):
-    print(f"Usage: canvigator.py [--dry-run] {' | '.join(tasks)}")
-    print("  --dry-run    Preview bonus changes without modifying Canvas")
+    print(f"Usage: canvigator.py [--dry-run] [--crn <CRN>] {' | '.join(tasks)}")
+    print("  --dry-run      Preview bonus changes without modifying Canvas")
+    print("  --crn <CRN>    Select course by CRN (last 5 digits of course code)")
     sys.exit(0)
 
 if task not in tasks:
@@ -45,8 +59,11 @@ canv_config = cu.CanvigatorConfig()
 # Initialize a new Canvas object
 canvas = canvasapi.Canvas(API_URL, API_KEY)
 
-# Prompt user to select a course
-course_choice = cu.selectCourse(canvas)
+# Select course by CRN if provided, otherwise prompt user interactively
+if crn:
+    course_choice = cu.selectCourseByCRN(canvas, crn)
+else:
+    course_choice = cu.selectCourse(canvas)
 
 print(f"\nSelected course: {course_choice.name}")
 

--- a/canvigator_quiz.py
+++ b/canvigator_quiz.py
@@ -28,6 +28,8 @@ class CanvigatorQuiz:
         self.verbose = verbose
         self.config = config
         self.quiz_name = self.canvas_quiz.title.lower().replace(" ", "_")
+        # Remove underscore between 'quiz' and number so filenames read 'quizX_' not 'quiz_X_'
+        self.quiz_name = re.sub(r'^quiz_(\d)', r'quiz\1', self.quiz_name)
         self.config.modifyQuizPrefix(self.quiz_name + "_")
 
         self.quiz_df = None
@@ -550,7 +552,7 @@ class CanvigatorQuiz:
             )
 
         print("\nAvailable dates with submission data:")
-        for i, d in enumerate(common_dates):
+        for i, d in enumerate(common_dates, start=1):
             print(f"[ {i} ] {d}")
 
         date_index = prompt_for_index("\nSelect date from above using index: ", len(common_dates) - 1)

--- a/canvigator_utils.py
+++ b/canvigator_utils.py
@@ -31,18 +31,18 @@ def setup_logging():
 
 
 def prompt_for_index(prompt_msg, max_index):
-    """Prompt the user for a numeric index, retrying on invalid input."""
+    """Prompt the user for a 1-based numeric index, retrying on invalid input. Returns a 0-based index."""
     while True:
         raw = input(prompt_msg)
         try:
             index = int(re.sub(r'\D', '', raw))
         except ValueError:
-            print(f"Invalid input. Please enter a number between 0 and {max_index}.")
+            print(f"Invalid input. Please enter a number between 1 and {max_index + 1}.")
             continue
-        if index < 0 or index > max_index:
-            print(f"Invalid selection. Please enter a number between 0 and {max_index}.")
+        if index < 1 or index > max_index + 1:
+            print(f"Invalid selection. Please enter a number between 1 and {max_index + 1}.")
             continue
-        return index
+        return index - 1
 
 
 def selectCSVFromList(directory, keyword, prompt_msg, verbose=False):
@@ -55,7 +55,7 @@ def selectCSVFromList(directory, keyword, prompt_msg, verbose=False):
         raise FileNotFoundError(f"No CSV files containing '{keyword}' found in {directory}")
 
     print("\nCSV Options:")
-    for i, f in enumerate(csv_files):
+    for i, f in enumerate(csv_files, start=1):
         fstring = f"[ {i:2d} ] {f}" if len(csv_files) > 10 else f"[ {i} ] {f}"
         print(fstring)
 
@@ -73,7 +73,7 @@ class CanvigatorConfig:
         """Simple file path configuration for data and figures (for both input and output)."""
         self.data_path = Path.cwd() / "data"
         self.figures_path = Path.cwd() / "figures"
-        self.quiz_prefix = "quiz_"
+        self.quiz_prefix = "quiz"
 
     def modifyQuizPrefix(self, new_prefix):
         """Modify the quiz file name prefix."""
@@ -97,7 +97,7 @@ def selectFromList(paginated_list, item_type="item"):
     """
     print(f"\nOptions:")
     subobject_list = []
-    for i, so in enumerate(paginated_list):
+    for i, so in enumerate(paginated_list, start=1):
         print(f"[ {i:2d} ] {so}")
         subobject_list.append(so)
 
@@ -107,6 +107,21 @@ def selectFromList(paginated_list, item_type="item"):
     index = prompt_for_index(f"\nSelect {item_type} from above using index in square brackets: ", len(subobject_list) - 1)
     logger.info(f"Selected {item_type} at index {index}: {subobject_list[index]}")
     return subobject_list[index]
+
+
+def selectCourseByCRN(canvas, crn):
+    """Select a course by its CRN (the last 5 digits of the course code). Returns the Canvas course object."""
+    for course in canvas.get_courses():
+        try:
+            if hasattr(course, 'course_code') and str(course.course_code).endswith(crn):
+                selected = canvas.get_course(course.id)
+                logger.info(f"Selected course by CRN {crn}: {selected.name}")
+                return selected
+        except Exception:
+            continue
+
+    print(f"Error: No course found with CRN '{crn}'.")
+    sys.exit(1)
 
 
 def selectCourse(canvas):
@@ -124,10 +139,7 @@ def selectCourse(canvas):
 
     for course in canvas.get_courses():
         try:
-            course_name = course.name
-
             # Check start and end dates
-            start_date = datetime.strptime(course.start_at, '%Y-%m-%dT%H:%M:%SZ') if course.start_at else None
             end_date = datetime.strptime(course.end_at, '%Y-%m-%dT%H:%M:%SZ') if course.end_at else None
 
             # Separate past and current courses
@@ -140,22 +152,22 @@ def selectCourse(canvas):
             print(f"Error: {e} - exiting")
             sys.exit(1)
 
-    # Prompt user to select between past and current courses
+    # Prompt user to select between current and past courses
     print("\nSelect Course Type:")
-    print("[ 0 ] Past Courses")
     print("[ 1 ] Current Courses")
+    print("[ 2 ] Past Courses")
     selection = prompt_for_index("\nSelect course type (using index in '[ ]'): ", 1)
 
     if selection == 0:
-        print("\nPast Courses:")
-        for i, course in enumerate(past_courses):
-            print(f"[ {i:2d} ] {course.name}")
-        valid_courses = past_courses
-    else:
         print("\nCurrent Courses:")
-        for i, course in enumerate(current_courses):
+        for i, course in enumerate(current_courses, start=1):
             print(f"[ {i:2d} ] {course.name}")
         valid_courses = current_courses
+    else:
+        print("\nPast Courses:")
+        for i, course in enumerate(past_courses, start=1):
+            print(f"[ {i:2d} ] {course.name}")
+        valid_courses = past_courses
 
     if not valid_courses:
         print("No courses found for the selected type.")


### PR DESCRIPTION
## Summary
- **1-based indexing**: All interactive selection menus now start at 1 instead of 0, and "Current Courses" is listed first
- **Quiz filename cleanup**: Removed extra underscore so filenames read `quiz1_...` instead of `quiz_1_...`
- **`--crn` option**: New `--crn <CRN>` flag selects a course by its 5-digit CRN, enabling automated/cron runs (e.g. `canvigator.py --crn 12345 activity`)
- **README update**: Added full documentation for the `auto-award-bonus` task and the `--crn` option
- **Minor cleanup**: Removed unused variables in `selectCourse()`, added 5-digit validation for `--crn`

## Test plan
- [ ] Run `canvigator.py --help` and verify updated usage text
- [ ] Run `canvigator.py activity` interactively and confirm menus use 1-based numbering with Current Courses first
- [ ] Run `canvigator.py --crn <CRN> activity` and confirm course is selected without prompts
- [ ] Run `canvigator.py --crn abc` and verify validation error
- [ ] Run `canvigator.py all-subs` and confirm output filenames use `quizX_` pattern (no extra underscore)
- [ ] Run `canvigator.py auto-award-bonus` and confirm it works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)