### PR TITLE
Add export-anon-data task for anonymized data export

### DIFF
--- a/canvigator.py
+++ b/canvigator.py
@@ -2,7 +2,7 @@
 import sys
 
 tasks = ['activity', 'award-bonus', 'award-bonus-partner-only', 'award-bonus-retake-only', 'pair', 'all-subs',
-         'get-quiz-questions', 'create-quiz']
+         'get-quiz-questions', 'create-quiz', 'export-anon-data']
 
 args = sys.argv[1:]
 dry_run = '--dry-run' in args
@@ -37,6 +37,44 @@ if task in ("help", "--help"):
 if task not in tasks:
     print(f"Invalid task: '{task}'. Valid tasks: {', '.join(tasks)}")
     sys.exit(1)
+
+# export-anon-data works with local files only — no Canvas API needed
+if task == 'export-anon-data':
+    import logging
+    from pathlib import Path
+    import canvigator_utils as cu
+    import canvigator_course as cc
+
+    cu.setup_logging()
+    logger = logging.getLogger(__name__)
+
+    data_base = Path.cwd() / "data"
+    if not data_base.exists():
+        print("No data directory found.")
+        sys.exit(1)
+
+    course_dirs = sorted([d for d in data_base.iterdir() if d.is_dir() and not d.name.startswith('.')])
+
+    if crn:
+        matches = [d for d in course_dirs if d.name.endswith(f"_{crn}")]
+        if not matches:
+            print(f"Error: No data directory found for CRN '{crn}'")
+            sys.exit(1)
+        course_data_path = matches[0]
+    else:
+        if not course_dirs:
+            print("No course data directories found.")
+            sys.exit(1)
+        print("\nCourse data directories:")
+        for i, d in enumerate(course_dirs, start=1):
+            print(f"[ {i:2d} ] {d.name}")
+        idx = cu.prompt_for_index("\nSelect course data directory: ", len(course_dirs) - 1)
+        course_data_path = course_dirs[idx]
+
+    print(f"\nSelected: {course_data_path.name}")
+    cc.exportAnonymizedData(course_data_path)
+    print("\n** Done ***\n")
+    sys.exit(0)
 
 import os
 import logging

--- a/canvigator_course.py
+++ b/canvigator_course.py
@@ -1,4 +1,6 @@
+import hashlib
 import logging
+import shutil
 import pandas as pd
 import canvigator_quiz as cq
 from canvigator_utils import today_str
@@ -122,3 +124,133 @@ class CanvigatorCourse:
         merged_acts_csv = data_path / f"course_activity_{today_str()}.csv"
         merged_acts.to_csv(merged_acts_csv, index=False)
         logger.info(f"Saved student activity to {merged_acts_csv}")
+
+
+def _make_anon_id(student_id):
+    """Hash a student ID to a numeric identifier with at most 10 digits."""
+    hash_hex = hashlib.sha256(str(student_id).encode()).hexdigest()
+    return int(hash_hex, 16) % 10_000_000_000
+
+
+def _collectStudentIds(csv_files):
+    """Scan CSV files and collect unique student IDs with associated name and sis_id."""
+    id_to_info = {}
+    for csv_file in csv_files:
+        df = pd.read_csv(csv_file)
+        cols = set(df.columns)
+
+        # Standard files with name + id columns (student data)
+        if 'name' in cols and 'id' in cols:
+            for _, row in df.iterrows():
+                sid = row['id']
+                if pd.notna(sid):
+                    sid = int(float(sid))
+                    if sid not in id_to_info:
+                        id_to_info[sid] = {'name': row['name'] if pd.notna(row['name']) else '', 'sis_id': ''}
+                    if 'sis_id' in cols and pd.notna(row.get('sis_id')):
+                        id_to_info[sid]['sis_id'] = row['sis_id']
+
+        # Pairing-style files with person1/id1, person2/id2, person3/id3
+        for suffix in ['1', '2', '3']:
+            id_col, name_col = f'id{suffix}', f'person{suffix}'
+            if id_col in cols and name_col in cols:
+                for _, row in df.iterrows():
+                    sid = row[id_col]
+                    if pd.notna(sid) and int(float(sid)) != -1:
+                        sid = int(float(sid))
+                        if sid not in id_to_info:
+                            id_to_info[sid] = {'name': row[name_col] if pd.notna(row[name_col]) else '', 'sis_id': ''}
+    return id_to_info
+
+
+def _anonymizeCsvFile(csv_file, anon_dir, id_to_anon):
+    """Create an anonymized copy of a single CSV file. Returns True if the file was modified."""
+    def map_student_id(x):
+        """Map a student ID to its anon_id, returning empty string for missing/invalid."""
+        if pd.isna(x):
+            return ''
+        x_int = int(float(x))
+        if x_int == -1:
+            return ''
+        return id_to_anon.get(x_int, '')
+
+    df = pd.read_csv(csv_file)
+    cols = set(df.columns)
+    modified = False
+
+    # Standard files: replace id with anon_id, drop name and sis_id
+    if 'name' in cols and 'id' in cols:
+        df['anon_id'] = df['id'].apply(map_student_id)
+        drop_cols = [c for c in ['name', 'id', 'sis_id'] if c in cols]
+        df = df.drop(columns=drop_cols)
+        remaining = [c for c in df.columns if c != 'anon_id']
+        df = df[['anon_id'] + remaining]
+        modified = True
+
+    # Pairing-style files: person1/id1 -> anon_id1, etc.
+    for suffix in ['1', '2', '3']:
+        id_col, name_col, anon_col = f'id{suffix}', f'person{suffix}', f'anon_id{suffix}'
+        if id_col in cols:
+            df[anon_col] = df[id_col].apply(map_student_id)
+            df = df.drop(columns=[id_col])
+            cols = set(df.columns)
+            modified = True
+        if name_col in cols:
+            df = df.drop(columns=[name_col])
+            cols = set(df.columns)
+            modified = True
+
+    df.to_csv(anon_dir / csv_file.name, index=False)
+    return modified
+
+
+def exportAnonymizedData(data_path):
+    """Export anonymized copies of all course data CSV files.
+
+    Creates an anonymized/ subdirectory with all CSVs stripped of identifying
+    columns (name, id, sis_id), replaced by a hashed anon_id. A mapping file
+    is saved in the original data directory. The anonymized directory is also
+    zipped for easy export.
+    """
+    from pathlib import Path
+    data_path = Path(data_path)
+
+    csv_files = sorted(f for f in data_path.glob("*.csv") if not f.name.startswith("anon_mapping_"))
+    if not csv_files:
+        print(f"No CSV files found in {data_path}")
+        return
+
+    anon_dir = data_path / "anonymized"
+    anon_dir.mkdir(exist_ok=True)
+
+    # Collect all unique student IDs from all CSV files
+    id_to_info = _collectStudentIds(csv_files)
+    if not id_to_info:
+        print("No student data found in CSV files.")
+        shutil.rmtree(anon_dir)
+        return
+
+    # Generate privacy-safe anon_ids (SHA-256 hash truncated to max 10 digits)
+    id_to_anon = {sid: _make_anon_id(sid) for sid in id_to_info}
+
+    # Save mapping file in original data directory
+    mapping_rows = []
+    for sid in sorted(id_to_info, key=lambda s: str(id_to_info[s]['name'])):
+        mapping_rows.append({'name': id_to_info[sid]['name'], 'id': sid, 'sis_id': id_to_info[sid]['sis_id'], 'anon_id': id_to_anon[sid]})
+    mapping_df = pd.DataFrame(mapping_rows, columns=['name', 'id', 'sis_id', 'anon_id'])
+    mapping_file = data_path / f"anon_mapping_{today_str()}.csv"
+    mapping_df.to_csv(mapping_file, index=False)
+    print(f"Saved mapping: {mapping_file.name}")
+    logger.info(f"Saved anonymization mapping to {mapping_file}")
+
+    # Create anonymized copies of each CSV
+    n_anonymized = sum(1 for f in csv_files if _anonymizeCsvFile(f, anon_dir, id_to_anon))
+
+    # Zip the anonymized directory
+    zip_path = data_path / f"anonymized_{today_str()}"
+    shutil.make_archive(str(zip_path), 'zip', data_path, 'anonymized')
+    print(f"Created: {zip_path.name}.zip")
+
+    n_total = len(csv_files)
+    print(f"Exported {n_total} file{'s' if n_total != 1 else ''} ({n_anonymized} anonymized) to {anon_dir.name}/")
+    logger.info(f"Exported {n_total} anonymized files to {zip_path}.zip")


### PR DESCRIPTION
## Summary
- Adds new `export-anon-data` task that anonymizes all course CSV files by replacing student identifiers (`name`, `id`, `sis_id`) with a privacy-safe SHA-256-based numeric `anon_id` (max 10 digits)
- Bypasses Canvas API entirely — selects course from existing `data/` subdirectories (supports `--crn` flag or interactive selection)
- Creates `anon_mapping_YYYYMMDD.csv` in the original data directory, an `anonymized/` subdirectory with all anonymized CSVs, and a `anonymized_YYYYMMDD.zip` for easy sharing
- Also handles pairing-style columns (`person1`/`id1`, `person2`/`id2`, `person3`/`id3`); files without student identifiers (e.g. quiz questions) are copied as-is

## Test plan
- [ ] Run `python canvigator.py --crn <CRN> export-anon-data` against a course with existing data files
- [ ] Verify mapping CSV contains correct `name`, `id`, `sis_id`, `anon_id` columns
- [ ] Verify anonymized CSVs have `anon_id` instead of `name`/`id`/`sis_id`
- [ ] Verify pairing/partner CSVs have `anon_id1`/`anon_id2`/`anon_id3` instead of `person`/`id` columns
- [ ] Verify quiz question CSVs (no student data) are copied unchanged
- [ ] Verify `.zip` file is created and contains all anonymized CSVs
- [ ] Run without `--crn` to confirm interactive directory selection works
- [ ] Run without Canvas env vars set to confirm no Canvas dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)