### PR TITLE
Pin CI Python to 3.12 to fix test timeout

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.x
+    - name: Set up Python 3.12
       uses: actions/setup-python@v3
       with:
-        python-version: '3.x'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         pip install --upgrade pip
@@ -29,10 +29,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.x
+    - name: Set up Python 3.12
       uses: actions/setup-python@v3
       with:
-        python-version: '3.x'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         pip install --upgrade pip


### PR DESCRIPTION
## Summary
- Pin both CI jobs (`lint` and `test`) to Python 3.12 instead of `3.x`
- `numpy==1.26.4` only publishes pre-built wheels for Python 3.9–3.12; using `3.x` resolves to 3.13+, forcing pip to compile numpy from source, which exceeds the 5-minute CI timeout

## Test plan
- [ ] Verify the CI `test` job completes within the 5-minute timeout
- [ ] Verify the CI `lint` job still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)