### PR TITLE
Fix bugs and add per-question timing/blur histograms

### DIFF
--- a/canvigator_course.py
+++ b/canvigator_course.py
@@ -133,7 +133,7 @@ class CanvigatorCourse:
                 gradebook_rows.append({
                     'name': student['name'],
                     'sortable_name': student['sortable_name'],
-                    'user_id': user_id,
+                    'id': user_id,
                     'assignment_name': assignment.name,
                     'assignment_id': assignment.id,
                     'points_possible': assignment.points_possible,
@@ -142,7 +142,7 @@ class CanvigatorCourse:
                 })
 
         gradebook_df = pd.DataFrame(gradebook_rows, columns=[
-            'name', 'sortable_name', 'user_id', 'assignment_name',
+            'name', 'sortable_name', 'id', 'assignment_name',
             'assignment_id', 'points_possible', 'grade', 'score'
         ])
 
@@ -213,11 +213,6 @@ def _collectStudentIds(csv_files):
                 if 'sis_id' in cols and pd.notna(row.get('sis_id')) and sid in id_to_info:
                     id_to_info[sid]['sis_id'] = row['sis_id']
 
-        # Gradebook files with name + user_id columns
-        if 'name' in cols and 'user_id' in cols:
-            for _, row in df.iterrows():
-                _addStudentId(id_to_info, row['user_id'], row['name'])
-
         # Pairing-style files with person1/id1, person2/id2, person3/id3
         for suffix in ['1', '2', '3']:
             id_col, name_col = f'id{suffix}', f'person{suffix}'
@@ -246,16 +241,7 @@ def _anonymizeCsvFile(csv_file, anon_dir, id_to_anon):
     # Standard files: replace id with anon_id, drop name and sis_id
     if 'name' in cols and 'id' in cols:
         df['anon_id'] = df['id'].apply(map_student_id)
-        drop_cols = [c for c in ['name', 'id', 'sis_id'] if c in cols]
-        df = df.drop(columns=drop_cols)
-        remaining = [c for c in df.columns if c != 'anon_id']
-        df = df[['anon_id'] + remaining]
-        modified = True
-
-    # Gradebook files: replace user_id with anon_id, drop name and sortable_name
-    if 'name' in cols and 'user_id' in cols:
-        df['anon_id'] = df['user_id'].apply(map_student_id)
-        drop_cols = [c for c in ['name', 'sortable_name', 'user_id'] if c in cols]
+        drop_cols = [c for c in ['name', 'id', 'sis_id', 'sortable_name'] if c in cols]
         df = df.drop(columns=drop_cols)
         remaining = [c for c in df.columns if c != 'anon_id']
         df = df[['anon_id'] + remaining]

--- a/canvigator_course.py
+++ b/canvigator_course.py
@@ -53,6 +53,7 @@ class CanvigatorCourse:
             if quiz.published and quiz.n_students is not None and quiz.n_students > 1:
                 quiz.generateQuestionHistograms()
                 quiz.getAllSubmissionsAndEvents()
+                quiz.generateFirstAttemptHistograms()
             else:
                 print("  Skipping (unpublished or insufficient submissions)")
 

--- a/canvigator_quiz.py
+++ b/canvigator_quiz.py
@@ -465,7 +465,9 @@ class CanvigatorQuiz:
         figure.set_size_inches(13, 3)
         for i, q in enumerate(self.quiz_question_ids):
             score_col = q + '_score'
-            axis[i].hist(self.quiz_df[score_col], bins=6, facecolor='#00447c', edgecolor='black', alpha=0.8)
+            col_data = self.quiz_df[score_col]
+            axis[i].hist(col_data, bins=6, facecolor='#00447c', edgecolor='black', alpha=0.8)
+            axis[i].axvline(col_data.mean(), color='black', linestyle='dashed', linewidth=1)
             axis[i].set_xlabel('score')
             axis[i].set_title('question: ' + q.split('_')[0])
         axis[0].set_ylabel('# of people')
@@ -489,6 +491,7 @@ class CanvigatorQuiz:
             if data:
                 bins = range(0, max(data) + 2) if all(isinstance(v, int) for v in data) else 10
                 axes[i].hist(data, bins=bins, facecolor=facecolor, edgecolor='black', alpha=0.8)
+                axes[i].axvline(sum(data) / len(data), color='black', linestyle='dashed', linewidth=1)
             axes[i].set_xlabel(xlabel)
             axes[i].set_title(f'Q{i + 1}')
         axes[0].set_ylabel('# of students')

--- a/canvigator_quiz.py
+++ b/canvigator_quiz.py
@@ -77,6 +77,44 @@ def _render_missed_bullets(missed_rows, question_info):
     return header + "\n".join(lines)
 
 
+def _extract_question_id(event):
+    """Extract quiz_question_id from a Canvas question_answered event, or None."""
+    edata = getattr(event, 'event_data', None)
+    if isinstance(edata, list) and edata:
+        first_entry = edata[0]
+        if isinstance(first_entry, dict):
+            return first_entry.get('quiz_question_id')
+    return None
+
+
+def _collect_timing_and_blurs(student_events, timing_by_q, blurs_by_q):
+    """Walk one student's first-attempt events and accumulate per-question timing and blur counts."""
+    prev_time = None
+    blur_count = 0
+
+    for evt in student_events:
+        if prev_time is None:
+            prev_time = evt['timestamp']
+
+        if evt['event'] == 'page_blurred':
+            blur_count += 1
+
+        if evt['event'] == 'question_answered':
+            qid = evt.get('question_id')
+            try:
+                qid_str = str(int(float(qid))) if pd.notna(qid) else None
+            except (TypeError, ValueError):
+                qid_str = None
+            if qid_str and qid_str in timing_by_q:
+                delta = (evt['timestamp'] - prev_time).total_seconds()
+                if 0 <= delta < 600:
+                    timing_by_q[qid_str].append(delta)
+                blurs_by_q[qid_str].append(blur_count)
+
+            prev_time = evt['timestamp']
+            blur_count = 0
+
+
 class CanvigatorQuiz:
     """A class for one quiz and associated attributes/data."""
 
@@ -420,7 +458,10 @@ class CanvigatorQuiz:
     def generateQuestionHistograms(self):
         """Draw a histogram of scores of each question."""
         mpl.style.use('seaborn-v0_8')
-        figure, axis = plt.subplots(1, len(self.quiz_question_ids), sharey=True)
+        n_questions = len(self.quiz_question_ids)
+        figure, axis = plt.subplots(1, n_questions, sharey=True)
+        if n_questions == 1:
+            axis = [axis]
         figure.set_size_inches(13, 3)
         for i, q in enumerate(self.quiz_question_ids):
             score_col = q + '_score'
@@ -433,6 +474,65 @@ class CanvigatorQuiz:
         figure.savefig(fig_path, dpi=200)
         plt.close('all')
         print(f"  ✓ Saved: {fig_path.name}")
+
+    def _plotPerQuestionHistogram(self, data_by_q, xlabel, facecolor, figure_name):
+        """Plot a row of per-question histograms and save the figure."""
+        question_ids = self.quiz_question_ids
+        n_questions = len(question_ids)
+        mpl.style.use('seaborn-v0_8')
+        fig, axes = plt.subplots(1, n_questions, sharey=True)
+        if n_questions == 1:
+            axes = [axes]
+        fig.set_size_inches(13, 3)
+        for i, qid in enumerate(question_ids):
+            data = data_by_q[qid]
+            if data:
+                bins = range(0, max(data) + 2) if all(isinstance(v, int) for v in data) else 10
+                axes[i].hist(data, bins=bins, facecolor=facecolor, edgecolor='black', alpha=0.8)
+            axes[i].set_xlabel(xlabel)
+            axes[i].set_title(f'Q{i + 1}')
+        axes[0].set_ylabel('# of students')
+        plt.tight_layout()
+        fig_path = self.figurePath(figure_name)
+        fig.savefig(fig_path, dpi=200)
+        plt.close('all')
+        print(f"  ✓ Saved: {fig_path.name}")
+
+    def generateFirstAttemptHistograms(self):
+        """Generate per-question timing and page-blur histograms for first attempts only.
+
+        Requires getAllSubmissionsAndEvents() to have been run first. Uses
+        question_answered events to compute per-question time deltas and counts
+        page_blurred events between consecutive answers.
+        """
+        events_df = getattr(self, 'all_subs_and_events', None)
+        if events_df is None or events_df.empty:
+            return
+
+        first = events_df[events_df['attempt'] == 1].copy()
+        if first.empty:
+            return
+
+        first['timestamp'] = pd.to_datetime(first['timestamp'])
+
+        question_ids = self.quiz_question_ids
+        if not question_ids:
+            return
+
+        timing_by_q = {qid: [] for qid in question_ids}
+        blurs_by_q = {qid: [] for qid in question_ids}
+
+        for sid in first['id'].unique():
+            student_events = first[first['id'] == sid].sort_values('timestamp').to_dict('records')
+            _collect_timing_and_blurs(student_events, timing_by_q, blurs_by_q)
+
+        has_data = any(timing_by_q[qid] or blurs_by_q[qid] for qid in question_ids)
+        if not has_data:
+            print("  (No per-question event data available for timing/blur histograms)")
+            return
+
+        self._plotPerQuestionHistogram(timing_by_q, 'seconds', '#00447c', 'timing_first_attempt')
+        self._plotPerQuestionHistogram(blurs_by_q, '# of page blurs', '#c44e52', 'blurs_first_attempt')
 
     def generateDistanceMatrix(self, only_present, distance_type='euclid'):
         """Calculate vector distance between all possible student pairs."""
@@ -1070,7 +1170,8 @@ class CanvigatorQuiz:
                             'id': sub.user_id,
                             'attempt': i + 1,
                             'event': event.event_type,
-                            'timestamp': event.created_at
+                            'timestamp': event.created_at,
+                            'question_id': _extract_question_id(event) if event.event_type == 'question_answered' else None,
                         })
                 except Exception:
                     print(f"  !!! could not get events for student id {sub.user_id} for attempt {i + 1}")
@@ -1079,7 +1180,7 @@ class CanvigatorQuiz:
         # Create DataFrames from the collected lists
         all_submissions = pd.DataFrame(submissions_data)
         all_subs_by_question = pd.DataFrame(subs_by_question_data)
-        all_subs_and_events = pd.DataFrame(subs_and_events_data, columns=['id', 'attempt', 'event', 'timestamp'])
+        all_subs_and_events = pd.DataFrame(subs_and_events_data, columns=['id', 'attempt', 'event', 'timestamp', 'question_id'])
 
         # do a full outer join of quiz_takers on 'id' to get names for the submission data
         if not all_submissions.empty:
@@ -1101,6 +1202,7 @@ class CanvigatorQuiz:
         all_sub_and_events_csv = self.config.data_path / f"{self.config.quiz_prefix}{self.canvas_quiz.id}_all_subs_and_events_{today_str()}.csv"
         all_subs_and_events.to_csv(all_sub_and_events_csv, index=False)
         print(f"  ✓ Saved: {all_sub_and_events_csv.name}")
+        self.all_subs_and_events = all_subs_and_events
 
     def _populateTimestamps(self, quiz_summary, row_index, sub):
         """Fill in start/finish/minutes for a student row using first-attempt times if available."""

--- a/canvigator_quiz.py
+++ b/canvigator_quiz.py
@@ -106,9 +106,9 @@ def _collect_timing_and_blurs(student_events, timing_by_q, blurs_by_q):
             except (TypeError, ValueError):
                 qid_str = None
             if qid_str and qid_str in timing_by_q:
-                delta = (evt['timestamp'] - prev_time).total_seconds()
-                if 0 <= delta < 600:
-                    timing_by_q[qid_str].append(delta)
+                delta_mins = (evt['timestamp'] - prev_time).total_seconds() / 60.0
+                if 0 <= delta_mins < 10:
+                    timing_by_q[qid_str].append(delta_mins)
                 blurs_by_q[qid_str].append(blur_count)
 
             prev_time = evt['timestamp']
@@ -531,7 +531,7 @@ class CanvigatorQuiz:
             print("  (No per-question event data available for timing/blur histograms)")
             return
 
-        self._plotPerQuestionHistogram(timing_by_q, 'seconds', '#00447c', 'timing_first_attempt')
+        self._plotPerQuestionHistogram(timing_by_q, 'minutes', '#00447c', 'timing_first_attempt')
         self._plotPerQuestionHistogram(blurs_by_q, '# of page blurs', '#c44e52', 'blurs_first_attempt')
 
     def generateDistanceMatrix(self, only_present, distance_type='euclid'):
@@ -1127,8 +1127,8 @@ class CanvigatorQuiz:
                 assignment_ids=[self.canvas_quiz.assignment_id],
                 include=['submission_history'])[0]
             n_attempts = len(student_subs.submission_history)
-            for i in range(n_attempts):
-                attempt_data = student_subs.submission_history[i]
+            for a in range(n_attempts):
+                attempt_data = student_subs.submission_history[a]
                 attempt_num = attempt_data['attempt']
 
                 # Compute raw score from per-question points to exclude any fudge points
@@ -1162,19 +1162,19 @@ class CanvigatorQuiz:
                     )
 
                 # see scratch_work.py for getting all events for this submission
-                this_submission_events = sub.get_submission_events(attempt=i + 1)  # get sub. events for this attempt
+                this_submission_events = sub.get_submission_events(attempt=attempt_num)
 
                 try:
                     for event in this_submission_events:
                         subs_and_events_data.append({
                             'id': sub.user_id,
-                            'attempt': i + 1,
+                            'attempt': attempt_num,
                             'event': event.event_type,
                             'timestamp': event.created_at,
                             'question_id': _extract_question_id(event) if event.event_type == 'question_answered' else None,
                         })
                 except Exception:
-                    print(f"  !!! could not get events for student id {sub.user_id} for attempt {i + 1}")
+                    print(f"  !!! could not get events for student id {sub.user_id} for attempt {attempt_num}")
                     continue
 
         # Create DataFrames from the collected lists

--- a/test_canvigator.py
+++ b/test_canvigator.py
@@ -190,13 +190,13 @@ class TestCollectStudentIds:
         assert len(result) == 1
 
     def test_gradebook_csv(self, tmp_path):
-        """Collects IDs from gradebook-style name/user_id columns."""
+        """Collects IDs from gradebook-style name/id columns."""
         from canvigator_course import _collectStudentIds
         csv_file = tmp_path / "gradebook.csv"
         df = pd.DataFrame({
             'name': ['Alice', 'Bob'],
             'sortable_name': ['Smith, Alice', 'Jones, Bob'],
-            'user_id': [100, 200],
+            'id': [100, 200],
             'assignment_name': ['Quiz 1', 'Quiz 1'],
             'score': [95, 87],
         })
@@ -257,7 +257,7 @@ class TestAnonymizeCsvFile:
         assert 'anon_id2' in result.columns
 
     def test_gradebook_file(self, tmp_path):
-        """Gradebook CSV: name/sortable_name/user_id replaced with anon_id."""
+        """Gradebook CSV: name/sortable_name/id replaced with anon_id."""
         from canvigator_course import _anonymizeCsvFile
         csv_file = tmp_path / "gradebook_20240101.csv"
         anon_dir = tmp_path / "anon"
@@ -266,7 +266,7 @@ class TestAnonymizeCsvFile:
         df = pd.DataFrame({
             'name': ['Alice', 'Bob'],
             'sortable_name': ['Smith, Alice', 'Jones, Bob'],
-            'user_id': [100, 200],
+            'id': [100, 200],
             'assignment_name': ['Quiz 1', 'Quiz 1'],
             'assignment_id': [10, 10],
             'points_possible': [100, 100],
@@ -282,7 +282,7 @@ class TestAnonymizeCsvFile:
         result = pd.read_csv(anon_dir / "gradebook_20240101.csv")
         assert 'name' not in result.columns
         assert 'sortable_name' not in result.columns
-        assert 'user_id' not in result.columns
+        assert 'id' not in result.columns
         assert 'anon_id' in result.columns
         assert list(result['anon_id']) == [1111111111, 2222222222]
         assert list(result['score']) == [95, 87]


### PR DESCRIPTION
## Summary
- **Rename gradebook `user_id` to `id`** for consistency with student_analysis and other CSV exports; simplifies anonymization by removing the separate gradebook branch from `_collectStudentIds` and `_anonymizeCsvFile`
- **Fix single-question histogram crash** where `plt.subplots(1, 1)` returns a bare Axes instead of an array
- **Add per-question timing and page-blur histograms** (first attempt only) to `get-all-subs`, giving instructors insight into how long students spend on each question and how often they leave the page
- **Add dashed mean line** to all per-question histograms (score, timing, blurs)
- **Fix loop variable shadowing** in `getAllSubmissionsAndEvents` where the inner attempt loop reused `i` from the outer student loop, causing events to use the loop index instead of the actual Canvas attempt number

## Test plan
- [x] All 52 existing tests pass
- [x] Both flake8 lint passes clean (complexity under 15)
- [ ] Run `get-all-subs` against a live course to verify the new timing/blur histograms generate correctly
- [ ] Run `get-gradebook` and `export-anon-data` to verify the `id` rename and anonymization still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)