### PR TITLE
Add generate-open-ended-questions task

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The `--crn` option selects a course by its CRN (the last 5 digits of the Canvas
 course code), bypassing the interactive course selection prompt. This is useful
 for automated/scheduled runs, e.g. `python canvigator.py --crn 12345 get-activity`.
 
-Available tasks: `award-bonus`, `award-bonus-partner-only`, `award-bonus-retake-only`, `create-pairs`, `create-quiz`, `export-anon-data`, `get-activity`, `get-all-subs`, `get-gradebook`, `get-quiz-questions`, `send-quiz-reminder`
+Available tasks: `award-bonus`, `award-bonus-partner-only`, `award-bonus-retake-only`, `create-pairs`, `create-quiz`, `export-anon-data`, `generate-open-ended-questions`, `get-activity`, `get-all-subs`, `get-gradebook`, `get-quiz-questions`, `send-quiz-reminder`
 
 All tasks begin by prompting you to select a course. Output files are written to
 `data/<course>/` and `figures/<course>/`, where `<course>` is derived from the
@@ -225,6 +225,44 @@ subdirectories (by `--crn` or interactively).
 | **Output** | `data/<course>/anon_mapping_YYYYMMDD.csv` — mapping of original IDs to anonymous IDs |
 | | `data/<course>/anonymized/` — directory containing anonymized copies of all CSVs |
 | | `data/<course>/anonymized_YYYYMMDD.zip` — zip archive of the anonymized directory |
+
+---
+
+#### `generate-open-ended-questions` — Generate open-ended questions from a tagged quiz
+
+Reads the tagged questions CSV for a selected quiz and uses a local LLM (via
+Ollama) in two steps to generate one open-ended follow-up question per quiz
+question:
+
+1. **Classify** — For each question, the LLM decides whether an oral
+   explanation ("explain") or a hand-drawn diagram ("draw") would be the better
+   way to assess student understanding. Inherently visual topics (e.g. data
+   structures, memory layouts, process flows) are classified as "draw"; verbal
+   topics (e.g. trade-offs, algorithm logic, definitions) as "explain".
+2. **Generate** — Using the classification, the LLM generates a self-contained
+   open-ended question. "Explain" questions begin with "Explain..." and target
+   a ~1 minute oral response. "Draw" questions begin with "Draw a diagram..." or
+   "Draw a figure..." and target a ~2 minute hand-drawn response.
+
+The output CSV is intended for instructor review — edit the questions and
+override the `question_mode` column as needed before using them with students.
+
+**Prerequisite**: run `get-quiz-questions --tag` for the same quiz first so the
+`*_questions_w_tags_*.csv` is on disk.
+
+| | Files |
+|---|---|
+| **Input** | `data/<course>/<quiz>_<id>_questions_w_tags_YYYYMMDD.csv` (from `get-quiz-questions --tag`) |
+| **Output** | `data/<course>/<quiz>_<id>_open_ended_YYYYMMDD.csv` |
+
+The output CSV contains columns: `question_id`, `position`, `question_name`,
+`keywords`, `question_mode` (`explain` or `draw`), `original_question_text`,
+`open_ended_question`.
+
+**Typical workflow:**
+1. Run `python canvigator.py --tag get-quiz-questions` and select the quiz.
+2. Run `python canvigator.py generate-open-ended-questions` and select the same quiz.
+3. Open the `*_open_ended_*.csv`, review/edit questions, and adjust any `question_mode` values as desired.
 
 ---
 

--- a/canvigator.py
+++ b/canvigator.py
@@ -8,6 +8,7 @@ task_descriptions = {
     'create-pairs': 'Create student pairings from quiz scores',
     'create-quiz': 'Create an unpublished placeholder quiz on Canvas',
     'export-anon-data': 'Export anonymized course data (no Canvas API needed)',
+    'generate-open-ended-questions': 'Generate open-ended questions from a tagged quiz (requires get-quiz-questions --tag)',
     'get-activity': 'Export student activity data',
     'get-all-subs': 'Export all quiz submissions and events',
     'get-gradebook': 'Export course gradebook',
@@ -28,6 +29,11 @@ def print_help():
     max_name = max(len(t) for t in tasks)
     for name, desc in task_descriptions.items():
         print(f"  {name:<{max_name}}  {desc}")
+    print("\nNotes:")
+    print("  generate-open-ended-questions uses a local LLM (via Ollama) in two steps:")
+    print("    1. Classifies each question as 'explain' (oral) or 'draw' (visual)")
+    print("    2. Generates a mode-appropriate open-ended question for instructor review")
+    print("  Output CSV includes a question_mode column so the instructor can override choices.")
 
 
 args = sys.argv[1:]
@@ -148,6 +154,12 @@ elif task == 'get-quiz-questions':
     print(f"\nSelected quiz: {quiz_choice.title}")
     quiz = cq.CanvigatorQuiz(canvas, course, quiz_choice, canv_config, verbose=False, skip_student_data=True)
     quiz.getQuizQuestions(tag=tag)
+
+elif task == 'generate-open-ended-questions':
+    quiz_choice = cu.selectFromList(course_choice.get_quizzes(), "quiz")
+    print(f"\nSelected quiz: {quiz_choice.title}")
+    quiz = cq.CanvigatorQuiz(canvas, course, quiz_choice, canv_config, verbose=False, skip_student_data=True)
+    quiz.generateOpenEndedQuestions()
 
 elif task == 'create-quiz':
     course.createQuiz()

--- a/canvigator_llm.py
+++ b/canvigator_llm.py
@@ -17,6 +17,53 @@ _TAG_SYSTEM_PROMPT = (
     "no numbering, no explanation, no quotes."
 )
 
+_CLASSIFY_SYSTEM_PROMPT = (
+    "You are an expert university instructor deciding how to assess student understanding. "
+    "Given a topic and details from an existing quiz question, decide whether the best way "
+    "to assess a student's understanding of this material is:\n"
+    "- \"explain\" — the student gives a verbal explanation in their own words, OR\n"
+    "- \"draw\" — the student draws a diagram, figure, or visual representation by hand.\n\n"
+    "Choose \"draw\" when the concept is inherently visual or spatial — for example: "
+    "data structures (trees, linked lists, graphs), memory layouts, network topologies, "
+    "circuit diagrams, process flows, state machines, architectural diagrams, or anything "
+    "where a picture would communicate the idea more clearly than words alone.\n\n"
+    "Choose \"explain\" when the concept is better communicated verbally — for example: "
+    "definitions, trade-offs, comparisons, reasoning about behavior, algorithm logic, "
+    "or conceptual understanding that doesn't map naturally to a picture.\n\n"
+    "Respond with ONLY the single word \"explain\" or \"draw\" — nothing else."
+)
+
+_EXPLAIN_SYSTEM_PROMPT = (
+    "You are an expert university instructor designing oral exam questions. "
+    "Given a topic and details from an existing quiz question, create ONE new open-ended "
+    "question that a student would answer verbally. The question should:\n"
+    "- Begin with \"Explain\" and require the student to explain a concept or idea clearly "
+    "in their own words\n"
+    "- Be answerable in under 1 minute of speaking\n"
+    "- Test understanding, not memorization — the student should demonstrate they grasp "
+    "the underlying idea, not just recall a definition\n"
+    "- Be self-contained (a student should understand what is being asked without seeing "
+    "the original quiz question)\n"
+    "- NOT be a yes/no question or a question that can be answered in one word\n\n"
+    "Respond with ONLY the question text — no preamble, no numbering, no explanation, "
+    "no quotation marks."
+)
+
+_DRAW_SYSTEM_PROMPT = (
+    "You are an expert university instructor designing visual assessment questions. "
+    "Given a topic and details from an existing quiz question, create ONE new question "
+    "that asks a student to draw a diagram or figure by hand. The question should:\n"
+    "- Begin with \"Draw a diagram\" or \"Draw a figure\" and clearly describe what the "
+    "student should illustrate\n"
+    "- Be completable in under 2 minutes of drawing\n"
+    "- Test understanding of structure, relationships, or processes — not artistic skill\n"
+    "- Be self-contained (a student should understand what is being asked without seeing "
+    "the original quiz question)\n"
+    "- Specify what key elements or labels should appear in the diagram\n\n"
+    "Respond with ONLY the question text — no preamble, no numbering, no explanation, "
+    "no quotation marks."
+)
+
 
 def _strip_html(text):
     """Reduce Canvas HTML question text to plain text suitable for prompting."""
@@ -131,3 +178,147 @@ def tag_questions(rows, model=None):
         tags = tag_question(row, client, model)
         row["keywords"] = ", ".join(tags)
     print("Tagging complete.")
+
+
+def _parse_question_mode(response):
+    """Parse the classify response into 'explain' or 'draw', defaulting to 'explain'."""
+    if not response:
+        return "explain"
+    token = response.strip().splitlines()[0].strip().lower().strip("\"'.,")
+    if token == "draw":
+        return "draw"
+    return "explain"
+
+
+def _build_classify_prompt(keywords, question_text, answers_json):
+    """Build the user-side prompt for the classify (explain vs. draw) step."""
+    clean_text = _strip_html(question_text)
+    labels = _answer_labels(answers_json)
+    parts = []
+    if keywords:
+        parts.append(f"Topic keywords: {keywords}")
+    if clean_text:
+        parts.append(f"Original question: {clean_text}")
+    if labels:
+        joined = " | ".join(labels[:6])
+        parts.append(f"Answer choices: {joined}")
+    parts.append("Best assessment mode (explain or draw):")
+    return "\n".join(parts)
+
+
+def _build_open_ended_prompt(keywords, question_text, answers_json, mode):
+    """Build the user-side prompt for generating one open-ended question."""
+    clean_text = _strip_html(question_text)
+    labels = _answer_labels(answers_json)
+    parts = []
+    if keywords:
+        parts.append(f"Topic keywords: {keywords}")
+    if clean_text:
+        parts.append(f"Original question: {clean_text}")
+    if labels:
+        joined = " | ".join(labels[:6])
+        parts.append(f"Answer choices from the original: {joined}")
+    if mode == "draw":
+        parts.append("Visual assessment question (must start with \"Draw a diagram\" or \"Draw a figure\"):")
+    else:
+        parts.append("Oral explanation question (must start with \"Explain\"):")
+    return "\n".join(parts)
+
+
+def classify_question_mode(row, client, model):
+    """Call the LLM to decide whether 'explain' or 'draw' is the better follow-up format."""
+    prompt = _build_classify_prompt(
+        row.get("keywords"),
+        row.get("question_text"),
+        row.get("answers"),
+    )
+    try:
+        resp = client.chat(
+            model=model,
+            messages=[
+                {"role": "system", "content": _CLASSIFY_SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+            options={"temperature": 0.1},
+        )
+        content = resp["message"]["content"]
+        return _parse_question_mode(content)
+    except Exception as e:
+        logger.warning(f"LLM classify failed for question {row.get('question_id')}: {e}")
+        return "explain"
+
+
+def generate_open_ended_question(row, client, model, mode):
+    """Call the LLM to generate one open-ended question of the given mode (explain or draw)."""
+    prompt = _build_open_ended_prompt(
+        row.get("keywords"),
+        row.get("question_text"),
+        row.get("answers"),
+        mode,
+    )
+    system_prompt = _DRAW_SYSTEM_PROMPT if mode == "draw" else _EXPLAIN_SYSTEM_PROMPT
+    try:
+        resp = client.chat(
+            model=model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ],
+            options={"temperature": 0.7},
+        )
+        content = resp["message"]["content"].strip()
+        # Take only the first paragraph in case the model over-generates
+        first_para = content.split("\n\n")[0].strip()
+        return first_para
+    except Exception as e:
+        logger.warning(f"LLM generation failed for question {row.get('question_id')}: {e}")
+        return ""
+
+
+def generate_open_ended_questions(rows, model=None):
+    """Classify then generate an open-ended question for each row; returns a list of result dicts.
+
+    Step 1: For each question, ask the LLM whether 'explain' or 'draw' is the
+    better assessment mode based on the topic and question content.
+    Step 2: Generate the open-ended question using the mode-specific prompt.
+    """
+    try:
+        import ollama
+    except ImportError as e:
+        raise RuntimeError(
+            "The 'ollama' package is required for generate-open-ended-questions. "
+            "Install with: pip install ollama"
+        ) from e
+
+    model = model or DEFAULT_MODEL
+    client = ollama.Client()
+
+    try:
+        client.list()
+    except Exception as e:
+        raise RuntimeError(
+            f"Could not reach Ollama at its configured host ({os.environ.get('OLLAMA_HOST', 'http://localhost:11434')}). "
+            f"Is the Ollama server running? Original error: {e}"
+        ) from e
+
+    total = len(rows)
+    print(f"Generating {total} open-ended questions with model '{model}'...")
+    results = []
+    for i, row in enumerate(rows, start=1):
+        label = row.get('question_name') or row.get('question_id')
+        print(f"  [{i}/{total}] {label} — classifying...", end="", flush=True)
+        mode = classify_question_mode(row, client, model)
+        print(f" {mode} — generating...", end="", flush=True)
+        question = generate_open_ended_question(row, client, model, mode)
+        print(" done")
+        results.append({
+            'question_id': row.get('question_id'),
+            'position': row.get('position'),
+            'question_name': row.get('question_name'),
+            'keywords': row.get('keywords'),
+            'question_mode': mode,
+            'original_question_text': _strip_html(row.get('question_text')),
+            'open_ended_question': question,
+        })
+    print("Generation complete.")
+    return results

--- a/canvigator_quiz.py
+++ b/canvigator_quiz.py
@@ -244,6 +244,55 @@ class CanvigatorQuiz:
         print(f"Saved {len(rows)} questions to {csv_name}")
         logger.info(f"Quiz questions saved: {csv_name}")
 
+    def generateOpenEndedQuestions(self):
+        """Generate open-ended oral exam questions from the tagged questions CSV.
+
+        Requires that get-quiz-questions --tag has been run first. Reads the
+        tagged questions CSV, sends each question to the LLM, and writes the
+        results to a new CSV for instructor review.
+        """
+        # Reuse _loadQuestionInfo's file-finding logic but we need the full CSV rows
+        file_prefix = f"{self.config.quiz_prefix}{self.canvas_quiz.id}_"
+        tagged_pattern = file_prefix + "questions_w_tags_"
+
+        all_files = os.listdir(self.config.data_path)
+        matching_dates = []
+        for f in all_files:
+            m = re.search(r'(\d{8})\.csv$', f)
+            if m and tagged_pattern in f:
+                matching_dates.append((m.group(1), f))
+
+        if not matching_dates:
+            raise FileNotFoundError(
+                f"No *_questions_w_tags_*.csv found for quiz '{self.quiz_name}'. "
+                f"Run 'python canvigator.py --crn <CRN> --tag get-quiz-questions' first."
+            )
+
+        matching_dates.sort(key=lambda t: t[0])
+        latest_file = self.config.data_path / matching_dates[-1][1]
+        print(f"  Using tagged questions from: {latest_file.name}")
+
+        df = pd.read_csv(latest_file)
+        if 'keywords' not in df.columns:
+            raise RuntimeError(
+                f"The file {latest_file.name} has no 'keywords' column. "
+                f"Re-run 'get-quiz-questions --tag' first."
+            )
+
+        rows = df.to_dict('records')
+
+        import canvigator_llm
+        results = canvigator_llm.generate_open_ended_questions(rows)
+
+        out_df = pd.DataFrame(results, columns=[
+            'question_id', 'position', 'question_name', 'keywords',
+            'question_mode', 'original_question_text', 'open_ended_question',
+        ])
+        csv_name = self.config.data_path / f"{file_prefix}open_ended_{today_str()}.csv"
+        out_df.to_csv(csv_name, index=False)
+        print(f"Saved {len(results)} open-ended questions to {csv_name}")
+        logger.info(f"Open-ended questions saved: {csv_name}")
+
     def _buildMissedBulletsForStudent(self, student_id, subs_by_q_df, question_info):
         """Return the missed-questions bullet section for one student, or None to skip."""
         if subs_by_q_df is None or subs_by_q_df.empty:

--- a/test_canvigator.py
+++ b/test_canvigator.py
@@ -695,3 +695,117 @@ class TestRenderMissedBullets:
         rows = [{'question_id': 101, 'points': 0.6666, 'points_possible': 1.0}]
         result = _render_missed_bullets(rows, self._question_info())
         assert "(0.67 / 1.00 pts)" in result
+
+
+# ---------------------------------------------------------------------------
+# canvigator_llm._parse_question_mode tests
+# ---------------------------------------------------------------------------
+
+class TestParseQuestionMode:
+    """Tests for _parse_question_mode classify response parser."""
+
+    def test_returns_explain_for_explain(self):
+        """Recognises 'explain' response."""
+        from canvigator_llm import _parse_question_mode
+        assert _parse_question_mode("explain") == "explain"
+
+    def test_returns_draw_for_draw(self):
+        """Recognises 'draw' response."""
+        from canvigator_llm import _parse_question_mode
+        assert _parse_question_mode("draw") == "draw"
+
+    def test_case_insensitive(self):
+        """Handles uppercase or mixed-case responses."""
+        from canvigator_llm import _parse_question_mode
+        assert _parse_question_mode("DRAW") == "draw"
+        assert _parse_question_mode("Explain") == "explain"
+
+    def test_strips_quotes_and_punctuation(self):
+        """Strips surrounding quotes and trailing punctuation."""
+        from canvigator_llm import _parse_question_mode
+        assert _parse_question_mode('"draw"') == "draw"
+        assert _parse_question_mode("'explain'.") == "explain"
+
+    def test_defaults_to_explain_on_empty(self):
+        """Empty/None defaults to explain."""
+        from canvigator_llm import _parse_question_mode
+        assert _parse_question_mode("") == "explain"
+        assert _parse_question_mode(None) == "explain"
+
+    def test_defaults_to_explain_on_unexpected(self):
+        """Unexpected text defaults to explain."""
+        from canvigator_llm import _parse_question_mode
+        assert _parse_question_mode("I think you should draw it") == "explain"
+
+    def test_uses_first_line_only(self):
+        """Only the first line is considered."""
+        from canvigator_llm import _parse_question_mode
+        assert _parse_question_mode("draw\nBecause it is visual...") == "draw"
+
+
+# ---------------------------------------------------------------------------
+# canvigator_llm._build_classify_prompt tests
+# ---------------------------------------------------------------------------
+
+class TestBuildClassifyPrompt:
+    """Tests for _build_classify_prompt construction."""
+
+    def test_includes_keywords(self):
+        """Keywords appear in the prompt."""
+        from canvigator_llm import _build_classify_prompt
+        result = _build_classify_prompt("linked lists", "What is a linked list?", None)
+        assert "Topic keywords: linked lists" in result
+
+    def test_ends_with_classify_cue(self):
+        """The prompt ends with the classification cue."""
+        from canvigator_llm import _build_classify_prompt
+        result = _build_classify_prompt("sorting", "How does quicksort work?", None)
+        assert result.endswith("Best assessment mode (explain or draw):")
+
+
+# ---------------------------------------------------------------------------
+# canvigator_llm._build_open_ended_prompt tests
+# ---------------------------------------------------------------------------
+
+class TestBuildOpenEndedPrompt:
+    """Tests for _build_open_ended_prompt prompt construction."""
+
+    def test_includes_keywords(self):
+        """Keywords appear in the prompt under the Topic keywords label."""
+        from canvigator_llm import _build_open_ended_prompt
+        result = _build_open_ended_prompt("recursion, base case", "What is recursion?", None, "explain")
+        assert "Topic keywords: recursion, base case" in result
+
+    def test_includes_question_text(self):
+        """Question text is stripped of HTML and included."""
+        from canvigator_llm import _build_open_ended_prompt
+        result = _build_open_ended_prompt("loops", "<p>What does a <b>for</b> loop do?</p>", None, "explain")
+        assert "What does a for loop do?" in result
+        assert "<p>" not in result
+
+    def test_includes_answer_choices(self):
+        """Answer choices from JSON are included."""
+        import json
+        from canvigator_llm import _build_open_ended_prompt
+        answers = json.dumps([{"text": "O(n)"}, {"text": "O(n^2)"}])
+        result = _build_open_ended_prompt("big-o", "What is the complexity?", answers, "explain")
+        assert "O(n)" in result
+        assert "O(n^2)" in result
+
+    def test_explain_mode_cue(self):
+        """Explain mode ends with the oral explanation cue."""
+        from canvigator_llm import _build_open_ended_prompt
+        result = _build_open_ended_prompt("sorting", "How does quicksort work?", None, "explain")
+        assert result.endswith('Oral explanation question (must start with "Explain"):')
+
+    def test_draw_mode_cue(self):
+        """Draw mode ends with the visual assessment cue."""
+        from canvigator_llm import _build_open_ended_prompt
+        result = _build_open_ended_prompt("trees", "What is a binary tree?", None, "draw")
+        assert result.endswith('Visual assessment question (must start with "Draw a diagram" or "Draw a figure"):')
+
+    def test_handles_empty_inputs(self):
+        """Empty/None inputs produce a minimal prompt with just the cue."""
+        from canvigator_llm import _build_open_ended_prompt
+        result = _build_open_ended_prompt("", "", None, "explain")
+        assert "Oral explanation question" in result


### PR DESCRIPTION
## Summary
- Adds a new `generate-open-ended-questions` task that uses a local LLM (Ollama/gemma4) in a two-step flow: first classifies each quiz question as "explain" (oral) or "draw" (visual), then generates a mode-appropriate open-ended follow-up question
- "Explain" questions start with "Explain..." for ~1 min oral responses; "draw" questions start with "Draw a diagram..." for ~2 min hand-drawn responses
- Outputs a CSV with a `question_mode` column so the instructor can review and override classifications before using questions with students
- Requires `get-quiz-questions --tag` to have been run first for the selected quiz

## Files changed
- `canvigator_llm.py` — New prompts (`_CLASSIFY_SYSTEM_PROMPT`, `_EXPLAIN_SYSTEM_PROMPT`, `_DRAW_SYSTEM_PROMPT`) and functions (`_parse_question_mode`, `_build_classify_prompt`, `classify_question_mode`, `generate_open_ended_question`, `generate_open_ended_questions`); updated `_build_open_ended_prompt` to accept a `mode` parameter
- `canvigator_quiz.py` — New `generateOpenEndedQuestions()` method on `CanvigatorQuiz`
- `canvigator.py` — New task entry, `--help` notes explaining the two-step flow
- `test_canvigator.py` — 15 new tests across `TestParseQuestionMode`, `TestBuildClassifyPrompt`, and `TestBuildOpenEndedPrompt`
- `README.md` — Full task documentation with input/output table and typical workflow

## Test plan
- [x] All 67 tests pass (`python -m pytest test_canvigator.py -v`)
- [x] Both flake8 lint passes clean
- [x] Run `python canvigator.py --tag get-quiz-questions` then `python canvigator.py generate-open-ended-questions` against a real quiz and verify the output CSV has sensible classify/generate results

🤖 Generated with [Claude Code](https://claude.com/claude-code)