### PR TITLE
Add follow-up questions pipeline and interactive send mode

### DIFF
--- a/canvigator.py
+++ b/canvigator.py
@@ -13,6 +13,7 @@ task_descriptions = {
     'get-all-subs': 'Export all quiz submissions and events',
     'get-gradebook': 'Export course gradebook',
     'get-quiz-questions': 'Export quiz question content',
+    'get-replies': 'Retrieve student replies to follow-up questions',
     'send-follow-up-question': 'Send the most-missed open-ended follow-up question to students',
     'send-quiz-reminder': 'Send quiz reminder messages to students',
 }
@@ -25,7 +26,8 @@ def print_help():
     print("Options:")
     print("  --dry-run      Preview changes without modifying Canvas (bonus, reminder, and follow-up tasks)")
     print("  --tag          Use a local LLM via Ollama to tag questions (get-quiz-questions only)")
-    print("  --crn <CRN>    Select course by CRN (last 5 digits of course code)\n")
+    print("  --crn <CRN>    Select course by CRN (last 5 digits of course code)")
+    print("  --reply-window-days N  Days to accept replies after follow-up sent (default: 5, get-replies only)\n")
     print("Tasks:")
     max_name = max(len(t) for t in tasks)
     for name, desc in task_descriptions.items():
@@ -58,6 +60,22 @@ if '--crn' in args:
         sys.exit(1)
     args.pop(crn_idx)  # remove '--crn'
     args.pop(crn_idx)  # remove the CRN value
+
+reply_window_days = 5
+if '--reply-window-days' in args:
+    rw_idx = args.index('--reply-window-days')
+    if rw_idx + 1 >= len(args):
+        print("Error: --reply-window-days requires a numeric value")
+        sys.exit(1)
+    try:
+        reply_window_days = int(args[rw_idx + 1])
+        if reply_window_days < 1:
+            raise ValueError
+    except ValueError:
+        print(f"Error: --reply-window-days must be a positive integer, got '{args[rw_idx + 1]}'")
+        sys.exit(1)
+    args.pop(rw_idx)  # remove '--reply-window-days'
+    args.pop(rw_idx)  # remove the value
 
 if len(args) < 1:
     print_help()
@@ -179,6 +197,12 @@ elif task == 'send-follow-up-question':
     print(f"\nSelected quiz: {quiz_choice.title}")
     quiz = cq.CanvigatorQuiz(canvas, course, quiz_choice, canv_config, verbose=False)
     quiz.sendFollowUpQuestions(dry_run=dry_run)
+
+elif task == 'get-replies':
+    quiz_choice = cu.selectFromList(course_choice.get_quizzes(), "quiz")
+    print(f"\nSelected quiz: {quiz_choice.title}")
+    quiz = cq.CanvigatorQuiz(canvas, course, quiz_choice, canv_config, verbose=False, skip_student_data=True)
+    quiz.getFollowUpReplies(reply_window_days=reply_window_days)
 
 elif task in ['create-pairs', 'award-bonus', 'award-bonus-partner-only', 'award-bonus-retake-only']:
     # Prompt user to select a quiz

--- a/canvigator.py
+++ b/canvigator.py
@@ -2,6 +2,7 @@
 import sys
 
 task_descriptions = {
+    'assess-replies': 'Assess student follow-up replies using local LLM (requires get-replies)',
     'award-bonus': 'Award partner + retake bonus points for a quiz',
     'award-bonus-partner-only': 'Award only the partner bonus points',
     'award-bonus-retake-only': 'Award only the retake bonus points',
@@ -37,6 +38,37 @@ def print_help():
     print("    1. Classifies each question as 'explain' (oral) or 'draw' (visual)")
     print("    2. Generates a mode-appropriate open-ended question for instructor review")
     print("  Output CSV includes a question_mode column so the instructor can override choices.")
+
+
+def _run_quiz_task(task, quiz, dry_run, tag, reply_window_days):
+    """Dispatch a quiz-level task to the appropriate method."""
+    if task == 'get-quiz-questions':
+        quiz.getQuizQuestions(tag=tag)
+    elif task == 'generate-open-ended-questions':
+        quiz.generateOpenEndedQuestions()
+    elif task == 'get-replies':
+        quiz.getFollowUpReplies(reply_window_days=reply_window_days)
+    elif task == 'assess-replies':
+        quiz.assessFollowUpReplies()
+    elif task == 'send-quiz-reminder':
+        quiz.sendQuizReminders(dry_run=dry_run)
+    elif task == 'send-follow-up-question':
+        quiz.sendFollowUpQuestions(dry_run=dry_run)
+    elif task == 'create-pairs':
+        quiz.openPresentCSV()
+        quiz.generateDistanceMatrix(only_present=True)
+        quiz.comparePairingMethods()
+        quiz.createStudentPairings(method='med', write_csv=True)
+    elif task == 'award-bonus':
+        quiz.detectPartners()
+        quiz.detectRetakers()
+        quiz.awardBonusPoints(dry_run=dry_run)
+    elif task == 'award-bonus-partner-only':
+        quiz.detectPartners()
+        quiz.awardBonusPoints(dry_run=dry_run)
+    elif task == 'award-bonus-retake-only':
+        quiz.detectRetakers()
+        quiz.awardBonusPoints(dry_run=dry_run)
 
 
 args = sys.argv[1:]
@@ -168,75 +200,18 @@ if task == 'get-activity':
 elif task == 'get-all-subs':
     course.getAllQuizzesAndSubmissions()
 
-elif task == 'get-quiz-questions':
-    quiz_choice = cu.selectFromList(course_choice.get_quizzes(), "quiz")
-    print(f"\nSelected quiz: {quiz_choice.title}")
-    quiz = cq.CanvigatorQuiz(canvas, course, quiz_choice, canv_config, verbose=False, skip_student_data=True)
-    quiz.getQuizQuestions(tag=tag)
-
-elif task == 'generate-open-ended-questions':
-    quiz_choice = cu.selectFromList(course_choice.get_quizzes(), "quiz")
-    print(f"\nSelected quiz: {quiz_choice.title}")
-    quiz = cq.CanvigatorQuiz(canvas, course, quiz_choice, canv_config, verbose=False, skip_student_data=True)
-    quiz.generateOpenEndedQuestions()
-
 elif task == 'create-quiz':
     course.createQuiz()
 
 elif task == 'get-gradebook':
     course.exportGradebook(canv_config.data_path)
 
-elif task == 'send-quiz-reminder':
+else:
+    # All remaining tasks require quiz selection
     quiz_choice = cu.selectFromList(course_choice.get_quizzes(), "quiz")
     print(f"\nSelected quiz: {quiz_choice.title}")
-    quiz = cq.CanvigatorQuiz(canvas, course, quiz_choice, canv_config, verbose=False)
-    quiz.sendQuizReminders(dry_run=dry_run)
-
-elif task == 'send-follow-up-question':
-    quiz_choice = cu.selectFromList(course_choice.get_quizzes(), "quiz")
-    print(f"\nSelected quiz: {quiz_choice.title}")
-    quiz = cq.CanvigatorQuiz(canvas, course, quiz_choice, canv_config, verbose=False)
-    quiz.sendFollowUpQuestions(dry_run=dry_run)
-
-elif task == 'get-replies':
-    quiz_choice = cu.selectFromList(course_choice.get_quizzes(), "quiz")
-    print(f"\nSelected quiz: {quiz_choice.title}")
-    quiz = cq.CanvigatorQuiz(canvas, course, quiz_choice, canv_config, verbose=False, skip_student_data=True)
-    quiz.getFollowUpReplies(reply_window_days=reply_window_days)
-
-elif task in ['create-pairs', 'award-bonus', 'award-bonus-partner-only', 'award-bonus-retake-only']:
-    # Prompt user to select a quiz
-    quiz_choice = cu.selectFromList(course_choice.get_quizzes(), "quiz")
-    print(f"\nSelected quiz: {quiz_choice.title}")
-
-    # Obtain quiz data for the selected task.
-    quiz = cq.CanvigatorQuiz(canvas, course, quiz_choice, canv_config, verbose=False)
-
-    if task == 'create-pairs':
-        # Open the CSV file with student data for who is present today and recalculate distance matrix.
-        quiz.openPresentCSV()
-        quiz.generateDistanceMatrix(only_present=True)
-
-        # Compare all four methods of pairings students
-        quiz.comparePairingMethods()
-
-        # Generate pairings for today using the median method
-        quiz.createStudentPairings(method='med', write_csv=True)
-
-    elif task == 'award-bonus':
-        # Detect partners and retakers, then award both bonus types
-        quiz.detectPartners()
-        quiz.detectRetakers()
-        quiz.awardBonusPoints(dry_run=dry_run)
-
-    elif task == 'award-bonus-partner-only':
-        # Detect partners and award only the partner bonus
-        quiz.detectPartners()
-        quiz.awardBonusPoints(dry_run=dry_run)
-
-    elif task == 'award-bonus-retake-only':
-        # Detect retakers and award only the retake bonus
-        quiz.detectRetakers()
-        quiz.awardBonusPoints(dry_run=dry_run)
+    skip = task in ('get-quiz-questions', 'generate-open-ended-questions', 'get-replies', 'assess-replies')
+    quiz = cq.CanvigatorQuiz(canvas, course, quiz_choice, canv_config, verbose=False, skip_student_data=skip)
+    _run_quiz_task(task, quiz, dry_run, tag, reply_window_days)
 
 print("\n*** Done ***\n")

--- a/canvigator.py
+++ b/canvigator.py
@@ -13,6 +13,7 @@ task_descriptions = {
     'get-all-subs': 'Export all quiz submissions and events',
     'get-gradebook': 'Export course gradebook',
     'get-quiz-questions': 'Export quiz question content',
+    'send-follow-up-question': 'Send the most-missed open-ended follow-up question to students',
     'send-quiz-reminder': 'Send quiz reminder messages to students',
 }
 tasks = list(task_descriptions.keys())
@@ -22,7 +23,7 @@ def print_help():
     """Print usage information with task descriptions."""
     print("Usage: canvigator.py [--dry-run] [--tag] [--crn <CRN>] <task>\n")
     print("Options:")
-    print("  --dry-run      Preview changes without modifying Canvas (bonus and reminder tasks)")
+    print("  --dry-run      Preview changes without modifying Canvas (bonus, reminder, and follow-up tasks)")
     print("  --tag          Use a local LLM via Ollama to tag questions (get-quiz-questions only)")
     print("  --crn <CRN>    Select course by CRN (last 5 digits of course code)\n")
     print("Tasks:")
@@ -172,6 +173,12 @@ elif task == 'send-quiz-reminder':
     print(f"\nSelected quiz: {quiz_choice.title}")
     quiz = cq.CanvigatorQuiz(canvas, course, quiz_choice, canv_config, verbose=False)
     quiz.sendQuizReminders(dry_run=dry_run)
+
+elif task == 'send-follow-up-question':
+    quiz_choice = cu.selectFromList(course_choice.get_quizzes(), "quiz")
+    print(f"\nSelected quiz: {quiz_choice.title}")
+    quiz = cq.CanvigatorQuiz(canvas, course, quiz_choice, canv_config, verbose=False)
+    quiz.sendFollowUpQuestions(dry_run=dry_run)
 
 elif task in ['create-pairs', 'award-bonus', 'award-bonus-partner-only', 'award-bonus-retake-only']:
     # Prompt user to select a quiz

--- a/canvigator_llm.py
+++ b/canvigator_llm.py
@@ -8,6 +8,7 @@ import re
 logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL = os.environ.get("OLLAMA_MODEL", "gemma4:31b")
+DEFAULT_AUDIO_MODEL = os.environ.get("OLLAMA_AUDIO_MODEL", "gemma4:e4b")
 
 _TAG_SYSTEM_PROMPT = (
     "You are a concise topic tagger for university quiz questions. "
@@ -273,6 +274,239 @@ def generate_open_ended_question(row, client, model, mode):
     except Exception as e:
         logger.warning(f"LLM generation failed for question {row.get('question_id')}: {e}")
         return ""
+
+
+_TRANSCRIBE_SYSTEM_PROMPT = (
+    "You are a transcription assistant. Listen to the audio and produce an accurate, "
+    "verbatim transcription of everything the speaker says. Output ONLY the transcription "
+    "text — no preamble, no labels, no timestamps, no commentary."
+)
+
+_ASSESS_EXPLAIN_SYSTEM_PROMPT = (
+    "You are a university instructor assessing a student's verbal explanation of a concept. "
+    "Given the original quiz question, the topic keywords, and the student's spoken response "
+    "(provided as a transcript), determine whether the student demonstrates a reasonable "
+    "understanding of the core concept.\n\n"
+    "A \"pass\" means the student demonstrates a reasonable understanding of the core concept, "
+    "even if their explanation is imprecise, incomplete, or uses informal language. "
+    "A \"fail\" means the student shows a fundamental misunderstanding, did not address the "
+    "question, or gave a response with no substantive content.\n\n"
+    "Respond in EXACTLY this format (two lines):\n"
+    "Result: pass\n"
+    "Feedback: Your 2-3 sentence feedback here.\n\n"
+    "Or:\n"
+    "Result: fail\n"
+    "Feedback: Your 2-3 sentence feedback here."
+)
+
+_ASSESS_DRAW_SYSTEM_PROMPT = (
+    "You are a university instructor assessing a student's hand-drawn diagram or figure. "
+    "Given the original quiz question, the topic keywords, and the student's drawing "
+    "(provided as an image), determine whether the drawing demonstrates a reasonable "
+    "understanding of the key concepts and relationships.\n\n"
+    "A \"pass\" means the drawing shows the essential structure or relationships, even if "
+    "it is rough, has minor inaccuracies, or is missing non-critical labels. "
+    "A \"fail\" means the drawing is fundamentally incorrect, shows the wrong structure, "
+    "is missing critical elements, or does not address the question.\n\n"
+    "Respond in EXACTLY this format (two lines):\n"
+    "Result: pass\n"
+    "Feedback: Your 2-3 sentence feedback here.\n\n"
+    "Or:\n"
+    "Result: fail\n"
+    "Feedback: Your 2-3 sentence feedback here."
+)
+
+
+def _parse_assessment(response):
+    r"""Parse a 'Result: pass/fail\nFeedback: ...' response into (result, feedback)."""
+    if not response:
+        return 'fail', 'No response from model.'
+
+    result = 'fail'
+    feedback = ''
+    for line in response.strip().splitlines():
+        line_stripped = line.strip()
+        if line_stripped.lower().startswith('result:'):
+            token = line_stripped[len('result:'):].strip().lower().strip('.,')
+            result = 'pass' if token == 'pass' else 'fail'
+        elif line_stripped.lower().startswith('feedback:'):
+            feedback = line_stripped[len('feedback:'):].strip()
+
+    if not feedback:
+        # Fallback: treat the whole response as feedback
+        feedback = response.strip()
+
+    return result, feedback
+
+
+def _build_assessment_prompt(keywords, open_ended_question, original_question_text, transcript=None):
+    """Build the user-side prompt for assessing a student response."""
+    parts = []
+    if keywords:
+        parts.append(f"Topic keywords: {keywords}")
+    if original_question_text:
+        parts.append(f"Original quiz question: {original_question_text}")
+    if open_ended_question:
+        parts.append(f"Follow-up question asked: {open_ended_question}")
+    if transcript:
+        parts.append(f"Student's response (transcript): {transcript}")
+    return "\n".join(parts)
+
+
+def transcribe_audio(audio_path, client, model):
+    """Transcribe an audio file using a multimodal model (e.g. gemma4:e4b)."""
+    try:
+        resp = client.chat(
+            model=model,
+            messages=[
+                {"role": "system", "content": _TRANSCRIBE_SYSTEM_PROMPT},
+                {"role": "user", "content": "Transcribe this audio recording.", "images": [audio_path]},
+            ],
+            options={"temperature": 0.1},
+        )
+        return resp["message"]["content"].strip()
+    except Exception as e:
+        logger.warning(f"Audio transcription failed for {audio_path}: {e}")
+        return ""
+
+
+def assess_explain(transcript, keywords, open_ended_question, original_question_text, client, model):
+    """Assess a student's verbal explanation using the transcript."""
+    prompt = _build_assessment_prompt(keywords, open_ended_question, original_question_text, transcript=transcript)
+    try:
+        resp = client.chat(
+            model=model,
+            messages=[
+                {"role": "system", "content": _ASSESS_EXPLAIN_SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+            options={"temperature": 0.3},
+        )
+        return _parse_assessment(resp["message"]["content"])
+    except Exception as e:
+        logger.warning(f"Explain assessment failed: {e}")
+        return 'fail', f'Assessment error: {e}'
+
+
+def assess_draw(image_path, keywords, open_ended_question, original_question_text, client, model):
+    """Assess a student's drawing by sending the image to a multimodal model."""
+    prompt = _build_assessment_prompt(keywords, open_ended_question, original_question_text)
+    try:
+        resp = client.chat(
+            model=model,
+            messages=[
+                {"role": "system", "content": _ASSESS_DRAW_SYSTEM_PROMPT},
+                {"role": "user", "content": prompt, "images": [image_path]},
+            ],
+            options={"temperature": 0.3},
+        )
+        return _parse_assessment(resp["message"]["content"])
+    except Exception as e:
+        logger.warning(f"Draw assessment failed for {image_path}: {e}")
+        return 'fail', f'Assessment error: {e}'
+
+
+def assess_replies(replies, question_info_row, model=None, audio_model=None):
+    """Assess a list of student reply dicts, returning a list of assessment result dicts.
+
+    Each reply dict should have keys: student_id, student_name, question_id,
+    question_mode, reply_text, attachment_path, audio_path.
+
+    question_info_row should have: keywords, open_ended_question, original_question_text.
+    """
+    try:
+        import ollama
+    except ImportError as e:
+        raise RuntimeError(
+            "The 'ollama' package is required for assess-replies. "
+            "Install with: pip install ollama"
+        ) from e
+
+    model = model or DEFAULT_MODEL
+    audio_model = audio_model or DEFAULT_AUDIO_MODEL
+    client = ollama.Client()
+
+    try:
+        client.list()
+    except Exception as e:
+        raise RuntimeError(
+            f"Could not reach Ollama at its configured host ({os.environ.get('OLLAMA_HOST', 'http://localhost:11434')}). "
+            f"Is the Ollama server running? Original error: {e}"
+        ) from e
+
+    keywords = question_info_row.get('keywords', '')
+    oe_question = question_info_row.get('open_ended_question', '')
+    orig_text = question_info_row.get('original_question_text', '')
+
+    total = len(replies)
+    print(f"Assessing {total} student replies with model '{model}'...")
+    results = []
+    for i, reply in enumerate(replies, start=1):
+        student_name = reply.get('student_name', '?')
+        mode = reply.get('question_mode', 'explain')
+        print(f"  [{i}/{total}] {student_name} ({mode})...", end="", flush=True)
+
+        transcript = ''
+        if mode == 'explain':
+            audio_path = reply.get('audio_path', '')
+            if audio_path:
+                print(" transcribing...", end="", flush=True)
+                transcript = transcribe_audio(audio_path, client, audio_model)
+            if not transcript:
+                # Fall back to reply text if no audio or transcription failed
+                transcript = _strip_html(reply.get('reply_text', ''))
+            if not transcript:
+                print(" no response content — skipped")
+                results.append({
+                    'student_id': reply['student_id'],
+                    'student_name': student_name,
+                    'question_id': reply['question_id'],
+                    'question_mode': mode,
+                    'result': 'fail',
+                    'feedback': 'No response content to assess (no audio and no text).',
+                    'transcript': '',
+                    'assessed_at': '',
+                })
+                continue
+            print(" assessing...", end="", flush=True)
+            result, feedback = assess_explain(transcript, keywords, oe_question, orig_text, client, model)
+        else:
+            # Draw mode
+            image_path = reply.get('attachment_path', '')
+            if not image_path:
+                print(" no image attached — skipped")
+                results.append({
+                    'student_id': reply['student_id'],
+                    'student_name': student_name,
+                    'question_id': reply['question_id'],
+                    'question_mode': mode,
+                    'result': 'fail',
+                    'feedback': 'No image attachment to assess.',
+                    'transcript': '',
+                    'assessed_at': '',
+                })
+                continue
+            transcript = ''
+            print(" assessing image...", end="", flush=True)
+            result, feedback = assess_draw(image_path, keywords, oe_question, orig_text, client, model)
+
+        from datetime import datetime, timezone
+        assessed_at = datetime.now(timezone.utc).isoformat()
+        print(f" {result}")
+
+        results.append({
+            'student_id': reply['student_id'],
+            'student_name': student_name,
+            'question_id': reply['question_id'],
+            'question_mode': mode,
+            'result': result,
+            'feedback': feedback,
+            'transcript': transcript,
+            'assessed_at': assessed_at,
+        })
+
+    print("Assessment complete.")
+    return results
 
 
 def generate_open_ended_questions(rows, model=None):

--- a/canvigator_quiz.py
+++ b/canvigator_quiz.py
@@ -1020,6 +1020,81 @@ class CanvigatorQuiz:
 
         return attachment_path, audio_path
 
+    def assessFollowUpReplies(self):
+        """Assess student replies using the local LLM.
+
+        Loads the latest followup_replies CSV, filters to only the latest reply
+        per student, loads the open-ended question context, and calls the LLM
+        to produce a pass/fail assessment with feedback. Outputs a
+        followup_assessments CSV.
+        """
+        # Load replies CSV
+        replies_df = self._loadFollowUpReplies()
+        # Filter to latest reply per student only
+        latest_replies = replies_df[replies_df['latest'] == True].to_dict('records')  # noqa: E712
+
+        if not latest_replies:
+            print("No student replies to assess.")
+            return
+
+        # Load the open-ended questions to get context for assessment
+        open_ended_rows = self._loadOpenEndedQuestions()
+
+        # All replies should share the same question_id (Phase 1 sends one question)
+        question_id = int(latest_replies[0]['question_id'])
+        oe_row = open_ended_rows.get(question_id)
+        if oe_row is None:
+            print(f"No open-ended question found for question_id {question_id}.")
+            return
+
+        print(f"\nAssessing {len(latest_replies)} student replies for question_id {question_id}")
+        print(f"  Question: {oe_row.get('open_ended_question', '')[:100]}...")
+        print(f"  Mode: {latest_replies[0].get('question_mode', 'explain')}")
+
+        import canvigator_llm
+        results = canvigator_llm.assess_replies(latest_replies, oe_row)
+
+        # Save assessments CSV
+        out_df = pd.DataFrame(results, columns=[
+            'student_id', 'student_name', 'question_id', 'question_mode',
+            'result', 'feedback', 'transcript', 'assessed_at',
+        ])
+        file_prefix = f"{self.config.quiz_prefix}{self.canvas_quiz.id}_"
+        csv_name = self.config.data_path / f"{file_prefix}followup_assessments_{today_str()}.csv"
+        out_df.to_csv(csv_name, index=False)
+
+        n_pass = sum(1 for r in results if r['result'] == 'pass')
+        n_fail = sum(1 for r in results if r['result'] == 'fail')
+        print(f"\n  Results: {n_pass} pass, {n_fail} fail")
+        print(f"  Assessments saved: {csv_name.name}")
+        logger.info(f"Follow-up assessments saved: {csv_name}")
+
+    def _loadFollowUpReplies(self):
+        """Load the latest *_followup_replies_*.csv.
+
+        Raises FileNotFoundError if no replies CSV exists for the quiz.
+        """
+        file_prefix = f"{self.config.quiz_prefix}{self.canvas_quiz.id}_"
+        replies_pattern = file_prefix + "followup_replies_"
+
+        all_files = os.listdir(self.config.data_path)
+        matching_dates = []
+        for f in all_files:
+            m = re.search(r'(\d{8})\.csv$', f)
+            if m and replies_pattern in f:
+                matching_dates.append((m.group(1), f))
+
+        if not matching_dates:
+            raise FileNotFoundError(
+                f"No *_followup_replies_*.csv found for quiz '{self.quiz_name}'. "
+                f"Run 'get-replies' first."
+            )
+
+        matching_dates.sort(key=lambda t: t[0])
+        latest_file = self.config.data_path / matching_dates[-1][1]
+        print(f"  Using replies from: {latest_file.name}")
+        return pd.read_csv(latest_file)
+
     SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 
     def _spin(self, frame, message, indent=2):

--- a/canvigator_quiz.py
+++ b/canvigator_quiz.py
@@ -667,10 +667,51 @@ class CanvigatorQuiz:
             )
             messages.append((student_id, student_name, message_str, f"missed Q{position}"))
 
-        self._sendOrPreviewMessages(messages, subject_str, quiz_name, self.canvas_quiz.points_possible, dry_run)
+        if dry_run:
+            self._sendOrPreviewMessages(messages, subject_str, quiz_name, self.canvas_quiz.points_possible, dry_run)
+            self._saveFollowUpManifest(messages, most_missed_qid, question_mode, subject_str, dry_run)
+        else:
+            sent_messages = self._interactiveSendFollowUps(messages, subject_str, quiz_name, self.canvas_quiz.points_possible)
+            if sent_messages:
+                self._saveFollowUpManifest(sent_messages, most_missed_qid, question_mode, subject_str, dry_run)
 
-        # Save the follow-up manifest CSV
-        self._saveFollowUpManifest(messages, most_missed_qid, question_mode, subject_str, dry_run)
+    def _interactiveSendFollowUps(self, messages, subject_str, quiz_name, points_possible):
+        """Interactively prompt the instructor to send or skip each follow-up message.
+
+        For each student, displays the message preview and asks the instructor
+        to type 'send' or 'skip' (default: skip). Returns the list of messages
+        that were actually sent.
+        """
+        if not messages:
+            print("No follow-up messages to send — all students scored perfectly!")
+            return []
+
+        print(f"\nQuiz: {quiz_name} ({points_possible} points possible)")
+        print(f"Follow-up messages to review: {len(messages)}")
+        print("For each student, enter 'send' to send or press Enter to skip.\n")
+
+        sent_messages = []
+        for i, (student_id, student_name, message_str, reason) in enumerate(messages, 1):
+            print(f"--- Student {i}/{len(messages)} ---")
+            print(f"  To: {student_name} (id: {student_id}, {reason})")
+            print(f"  Subject: {subject_str}")
+            print(f"  Message: {message_str}\n")
+
+            choice = input(f"  Send to {student_name}? [send/SKIP]: ").strip().lower()
+            if choice == 'send':
+                self.canvas.create_conversation(
+                    [str(student_id)], message_str, subject=subject_str, force_new=True
+                )
+                print("  -> Sent!\n")
+                sent_messages.append((student_id, student_name, message_str, reason))
+            else:
+                print("  -> Skipped.\n")
+
+        n_sent = len(sent_messages)
+        n_skipped = len(messages) - n_sent
+        print(f"\n{n_sent} follow-up(s) sent, {n_skipped} skipped.")
+        logger.info(f"Follow-up questions interactive send: {n_sent} sent, {n_skipped} skipped for {quiz_name}")
+        return sent_messages
 
     def _findMostMissedQuestion(self, subs_by_q_df, question_info):
         """Return the question_id with the highest miss rate, or None if all are perfect.

--- a/canvigator_quiz.py
+++ b/canvigator_quiz.py
@@ -788,6 +788,238 @@ class CanvigatorQuiz:
         print(f"  Manifest saved: {csv_name.name}")
         logger.info(f"Follow-up manifest saved: {csv_name}")
 
+    def getFollowUpReplies(self, reply_window_days=5):
+        """Retrieve student replies to follow-up questions from Canvas conversations.
+
+        Loads the followup_sent manifest CSV to know which conversations to look
+        for, then uses the Canvas conversations API to find matching threads and
+        extract student replies (text, audio, image attachments). Downloads media
+        to a replies/ subdirectory. Outputs a followup_replies CSV.
+        """
+        from datetime import datetime, timedelta, timezone
+
+        manifest = self._loadFollowUpManifest()
+        subject_str = manifest['conversation_subject'].iloc[0]
+        question_id = int(manifest['question_id'].iloc[0])
+        question_mode = manifest['question_mode'].iloc[0]
+
+        # Parse the sent_at timestamp to compute the reply window cutoff
+        sent_at_str = manifest['sent_at'].iloc[0]
+        sent_at = datetime.fromisoformat(sent_at_str.replace('Z', '+00:00'))
+        cutoff = sent_at + timedelta(days=reply_window_days)
+        now = datetime.now(timezone.utc)
+
+        print(f"\nLooking for replies to: {subject_str}")
+        print(f"  Reply window: {reply_window_days} days (cutoff: {cutoff.strftime('%Y-%m-%d %H:%M UTC')})")
+        if now < cutoff:
+            remaining = cutoff - now
+            print(f"  Window still open — {remaining.days}d {remaining.seconds // 3600}h remaining")
+
+        # Build a set of student IDs we expect replies from
+        expected_students = set(manifest['student_id'].astype(int))
+        student_names = dict(zip(manifest['student_id'].astype(int), manifest['student_name']))
+
+        # Get the instructor's user ID to filter out instructor messages
+        instructor_id = self.canvas.get_current_user().id
+
+        # Search sent conversations for threads matching our subject
+        print("\n  Scanning sent conversations...")
+        matching_convos = self._findConversationsBySubject(subject_str)
+        print(f"  Found {len(matching_convos)} matching conversation(s)")
+
+        # Ensure the replies directory exists
+        replies_dir = self.config.data_path / "replies"
+        replies_dir.mkdir(exist_ok=True)
+
+        # Extract replies from each matching conversation
+        all_replies = []
+        n_with_reply = 0
+        file_prefix = f"{self.config.quiz_prefix}{self.canvas_quiz.id}_"
+
+        for convo_summary in matching_convos:
+            # Get full conversation with messages (don't mark as read)
+            convo = self.canvas.get_conversation(convo_summary.id, auto_mark_as_read=False)
+            messages = getattr(convo, 'messages', [])
+            audience = set(getattr(convo, 'audience', []))
+
+            # Determine which student this conversation belongs to
+            student_ids_in_convo = audience & expected_students
+            if not student_ids_in_convo:
+                continue
+            student_id = next(iter(student_ids_in_convo))
+            student_name = student_names.get(student_id, f"Unknown ({student_id})")
+
+            # Collect student replies (messages not from the instructor)
+            student_replies = self._extractStudentReplies(
+                messages, instructor_id, sent_at, cutoff
+            )
+
+            if student_replies:
+                n_with_reply += 1
+
+            for i, msg in enumerate(student_replies):
+                is_latest = (i == 0)  # messages are newest-first from Canvas
+                attachment_path, audio_path = self._downloadReplyMedia(
+                    msg, student_id, question_id, file_prefix, replies_dir
+                )
+                replied_at = msg.get('created_at', '')
+
+                all_replies.append({
+                    'student_id': student_id,
+                    'student_name': student_name,
+                    'question_id': question_id,
+                    'question_mode': question_mode,
+                    'message_id': msg.get('id', ''),
+                    'reply_text': msg.get('body', ''),
+                    'has_attachment': bool(attachment_path),
+                    'attachment_path': attachment_path or '',
+                    'has_audio': bool(audio_path),
+                    'audio_path': audio_path or '',
+                    'replied_at': replied_at,
+                    'latest': is_latest,
+                })
+
+        # Save the replies CSV
+        replies_df = pd.DataFrame(all_replies)
+        csv_name = self.config.data_path / f"{file_prefix}followup_replies_{today_str()}.csv"
+        replies_df.to_csv(csv_name, index=False)
+
+        # Print summary
+        n_expected = len(expected_students)
+        print(f"\n  Students who received follow-up: {n_expected}")
+        print(f"  Students who replied: {n_with_reply}")
+        print(f"  Students with no reply: {n_expected - n_with_reply}")
+        print(f"  Total reply messages: {len(all_replies)}")
+        n_attachments = sum(1 for r in all_replies if r['has_attachment'])
+        n_audio = sum(1 for r in all_replies if r['has_audio'])
+        if n_attachments:
+            print(f"  Image attachments downloaded: {n_attachments}")
+        if n_audio:
+            print(f"  Audio recordings downloaded: {n_audio}")
+        print(f"  Replies saved: {csv_name.name}")
+        logger.info(f"Follow-up replies saved: {csv_name}")
+
+    def _loadFollowUpManifest(self):
+        """Load the latest *_followup_sent_*.csv manifest (non-dryrun only).
+
+        Raises FileNotFoundError if no manifest exists for the quiz.
+        """
+        file_prefix = f"{self.config.quiz_prefix}{self.canvas_quiz.id}_"
+        manifest_pattern = file_prefix + "followup_sent_"
+
+        all_files = os.listdir(self.config.data_path)
+        matching_dates = []
+        for f in all_files:
+            # Skip dryrun manifests
+            if '_dryrun_' in f:
+                continue
+            m = re.search(r'(\d{8})\.csv$', f)
+            if m and manifest_pattern in f:
+                matching_dates.append((m.group(1), f))
+
+        if not matching_dates:
+            raise FileNotFoundError(
+                f"No *_followup_sent_*.csv found for quiz '{self.quiz_name}'. "
+                f"Run 'send-follow-up-question' first."
+            )
+
+        matching_dates.sort(key=lambda t: t[0])
+        latest_file = self.config.data_path / matching_dates[-1][1]
+        print(f"  Using follow-up manifest: {latest_file.name}")
+
+        df = pd.read_csv(latest_file)
+        required_cols = {'student_id', 'student_name', 'question_id', 'question_mode', 'conversation_subject', 'sent_at'}
+        missing = required_cols - set(df.columns)
+        if missing:
+            raise RuntimeError(f"Manifest {latest_file.name} is missing columns: {missing}")
+        return df
+
+    def _findConversationsBySubject(self, subject_str):
+        """Return a list of Conversation objects from sent conversations matching the given subject."""
+        matching = []
+        for convo in self.canvas.get_conversations(scope='sent'):
+            if getattr(convo, 'subject', '') == subject_str:
+                matching.append(convo)
+        return matching
+
+    def _extractStudentReplies(self, messages, instructor_id, sent_at, cutoff):
+        """Filter conversation messages to only student replies within the reply window.
+
+        Returns a list of message dicts, newest first (Canvas's default order).
+        Messages from the instructor or outside the window are excluded.
+        """
+        from datetime import datetime
+
+        replies = []
+        for msg in messages:
+            # Skip instructor's own messages
+            if msg.get('author_id') == instructor_id:
+                continue
+            # Skip system-generated messages
+            if msg.get('generated', False):
+                continue
+            # Check reply window
+            created_str = msg.get('created_at', '')
+            if created_str:
+                try:
+                    created = datetime.fromisoformat(created_str.replace('Z', '+00:00'))
+                    if created < sent_at or created > cutoff:
+                        logger.info(f"Skipping message {msg.get('id')} — outside reply window "
+                                    f"(created: {created_str}, window: {sent_at} to {cutoff})")
+                        continue
+                except (ValueError, TypeError):
+                    pass  # If we can't parse the timestamp, include the message
+            replies.append(msg)
+        return replies
+
+    def _downloadReplyMedia(self, msg, student_id, question_id, file_prefix, replies_dir):
+        """Download any attachment or audio from a reply message.
+
+        Returns (attachment_path, audio_path) — each is a string path relative
+        to the data directory, or None if no media of that type.
+        """
+        attachment_path = None
+        audio_path = None
+
+        # Download image/file attachments
+        attachments = msg.get('attachments', [])
+        if attachments:
+            att = attachments[0]  # Take the first attachment
+            att_url = att.get('url', '')
+            filename = att.get('filename', '') or att.get('display_name', 'attachment')
+            ext = os.path.splitext(filename)[1] or '.bin'
+            local_name = f"{file_prefix}{student_id}_{question_id}{ext}"
+            local_path = replies_dir / local_name
+            try:
+                resp = requests.get(att_url, timeout=30)
+                resp.raise_for_status()
+                with open(local_path, 'wb') as f:
+                    f.write(resp.content)
+                attachment_path = str(local_path.relative_to(self.config.data_path.parent))
+                logger.info(f"Downloaded attachment for student {student_id}: {local_name}")
+            except Exception as e:
+                logger.warning(f"Failed to download attachment for student {student_id}: {e}")
+
+        # Download audio/video media comment
+        media_comment = msg.get('media_comment')
+        if media_comment:
+            media_url = media_comment.get('url', '')
+            media_type = media_comment.get('media_type', 'audio')
+            ext = '.m4a' if media_type == 'audio' else '.mp4'
+            local_name = f"{file_prefix}{student_id}_{question_id}{ext}"
+            local_path = replies_dir / local_name
+            try:
+                resp = requests.get(media_url, timeout=60)
+                resp.raise_for_status()
+                with open(local_path, 'wb') as f:
+                    f.write(resp.content)
+                audio_path = str(local_path.relative_to(self.config.data_path.parent))
+                logger.info(f"Downloaded media for student {student_id}: {local_name}")
+            except Exception as e:
+                logger.warning(f"Failed to download media for student {student_id}: {e}")
+
+        return attachment_path, audio_path
+
     SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 
     def _spin(self, frame, message, indent=2):

--- a/canvigator_quiz.py
+++ b/canvigator_quiz.py
@@ -575,6 +575,219 @@ class CanvigatorQuiz:
         print(f"\n{len(messages)} reminder(s) {action} ({', '.join(summary_parts)}).")
         logger.info(f"Quiz reminders {'(dry run) ' if dry_run else ''}{action}: {len(messages)} for {quiz_name}")
 
+    def sendFollowUpQuestions(self, dry_run=False):
+        """Send the most-missed open-ended follow-up question to students who missed it.
+
+        Requires that get-quiz-questions --tag and generate-open-ended-questions
+        have both been run for this quiz. Auto-refreshes submission data to pick
+        up recent attempts.
+        """
+        quiz_name = self.canvas_quiz.title
+
+        # Load question metadata (from *_questions_w_tags_*.csv)
+        question_info = self._loadQuestionInfo()
+
+        # Load the open-ended questions CSV
+        open_ended_rows = self._loadOpenEndedQuestions()
+
+        # Refresh submission data for up-to-date per-question scores
+        print("\nFetching latest submissions for follow-up question targeting...")
+        self.getAllSubmissionsAndEvents()
+        subs_by_q_df = self.all_subs_by_question
+
+        if subs_by_q_df is None or subs_by_q_df.empty:
+            print("No submission data available — cannot determine missed questions.")
+            return
+
+        # Find the most-missed question
+        most_missed_qid = self._findMostMissedQuestion(subs_by_q_df, question_info)
+        if most_missed_qid is None:
+            print("All students scored perfectly on all questions — no follow-up needed!")
+            return
+
+        info = question_info[most_missed_qid]
+        position = info['position']
+        keywords = info['keywords']
+
+        # Look up the open-ended question for this question_id
+        oe_row = open_ended_rows.get(most_missed_qid)
+        if oe_row is None:
+            print(f"No open-ended question found for question_id {most_missed_qid} (Q{position}: {keywords}).")
+            print("Re-run 'generate-open-ended-questions' to regenerate.")
+            return
+
+        question_mode = oe_row.get('question_mode', 'explain')
+        open_ended_text = oe_row['open_ended_question']
+
+        print(f"\nMost-missed question: Q{position} — {keywords}")
+        print(f"  Mode: {question_mode}")
+        print(f"  Follow-up: {open_ended_text[:120]}{'...' if len(open_ended_text) > 120 else ''}")
+
+        # Build the list of students who missed this question on their latest attempt
+        students_who_missed = self._findStudentsWhoMissed(most_missed_qid, subs_by_q_df, question_info)
+
+        if not students_who_missed:
+            print("No students missed this question on their latest attempt — no follow-up needed!")
+            return
+
+        # Compose messages
+        if question_mode == 'draw':
+            instructions = (
+                "Please draw your answer on paper (or a tablet) and reply to this "
+                "message with a photo of your drawing attached using the attachment "
+                "button (the paperclip icon)."
+            )
+        else:
+            instructions = (
+                "Please reply to this message with a voice recording explaining "
+                "your answer. You can use the microphone button in the Canvas "
+                "message editor to record your response."
+            )
+
+        subject_str = f"Follow-Up Question - {quiz_name} - Q{position}"
+        enrolled = self.canvas_course.students
+        enrolled_map = {s['id']: s['name'] for s in enrolled}
+
+        messages = []
+        for student_id in students_who_missed:
+            student_name = enrolled_map.get(student_id)
+            if student_name is None:
+                continue
+            first_name = student_name.split()[0]
+            message_str = (
+                f"Hello {first_name}, based on your recent attempt on {quiz_name}, "
+                f"here is a follow-up question to help reinforce your understanding "
+                f"of the topic ({keywords}):\n\n"
+                f"{open_ended_text}\n\n"
+                f"{instructions}\n\n"
+                f"You can reply as many times as you'd like — only your most recent "
+                f"response will be assessed.\n\n"
+                f"NOTE: This is an auto-generated message, please let me know if you "
+                f"have any questions/concerns/suggestions about it."
+            )
+            messages.append((student_id, student_name, message_str, f"missed Q{position}"))
+
+        self._sendOrPreviewMessages(messages, subject_str, quiz_name, self.canvas_quiz.points_possible, dry_run)
+
+        # Save the follow-up manifest CSV
+        self._saveFollowUpManifest(messages, most_missed_qid, question_mode, subject_str, dry_run)
+
+    def _findMostMissedQuestion(self, subs_by_q_df, question_info):
+        """Return the question_id with the highest miss rate, or None if all are perfect.
+
+        Miss rate = fraction of students whose latest attempt scored below
+        points_possible for that question.
+        """
+        # Use only the latest attempt per student (each student has multiple rows — one per question)
+        max_attempt_per_student = subs_by_q_df.groupby('id')['attempt'].transform('max')
+        latest_attempts = subs_by_q_df[subs_by_q_df['attempt'] == max_attempt_per_student]
+
+        miss_rates = {}
+        for qid, info in question_info.items():
+            pp = info.get('points_possible')
+            if pp is None:
+                continue
+            q_rows = latest_attempts[latest_attempts['question_id'] == qid]
+            if q_rows.empty:
+                continue
+            n_total = len(q_rows)
+            n_missed = sum(1 for _, row in q_rows.iterrows()
+                           if pd.notna(row.get('points')) and float(row['points']) < float(pp))
+            miss_rates[qid] = n_missed / n_total if n_total > 0 else 0.0
+
+        if not miss_rates or max(miss_rates.values()) == 0:
+            return None
+
+        # Report top-5 miss rates for instructor visibility
+        sorted_rates = sorted(miss_rates.items(), key=lambda t: t[1], reverse=True)
+        print("\nQuestion miss rates (latest attempt):")
+        for qid, rate in sorted_rates[:5]:
+            info = question_info.get(qid, {})
+            label = f"Q{info.get('position', '?')} ({info.get('keywords', '')})"
+            print(f"  {label}: {rate:.0%}")
+
+        return sorted_rates[0][0]
+
+    def _findStudentsWhoMissed(self, question_id, subs_by_q_df, question_info):
+        """Return a list of student IDs who scored below points_possible on the given question in their latest attempt."""
+        pp = question_info.get(question_id, {}).get('points_possible')
+        if pp is None:
+            return []
+
+        max_attempt_per_student = subs_by_q_df.groupby('id')['attempt'].transform('max')
+        latest_attempts = subs_by_q_df[subs_by_q_df['attempt'] == max_attempt_per_student]
+        q_rows = latest_attempts[latest_attempts['question_id'] == question_id]
+
+        missed_ids = []
+        for _, row in q_rows.iterrows():
+            points = row.get('points')
+            if points is not None and pd.notna(points) and float(points) < float(pp):
+                missed_ids.append(row['id'])
+        return missed_ids
+
+    def _loadOpenEndedQuestions(self):
+        """Load the latest *_open_ended_*.csv and return a dict keyed by question_id.
+
+        Raises FileNotFoundError if no open-ended CSV exists for the quiz.
+        """
+        file_prefix = f"{self.config.quiz_prefix}{self.canvas_quiz.id}_"
+        oe_pattern = file_prefix + "open_ended_"
+
+        all_files = os.listdir(self.config.data_path)
+        matching_dates = []
+        for f in all_files:
+            m = re.search(r'(\d{8})\.csv$', f)
+            if m and oe_pattern in f:
+                matching_dates.append((m.group(1), f))
+
+        if not matching_dates:
+            raise FileNotFoundError(
+                f"No *_open_ended_*.csv found for quiz '{self.quiz_name}'. "
+                f"Run 'python canvigator.py generate-open-ended-questions' first."
+            )
+
+        matching_dates.sort(key=lambda t: t[0])
+        latest_file = self.config.data_path / matching_dates[-1][1]
+        print(f"  Using open-ended questions from: {latest_file.name}")
+
+        df = pd.read_csv(latest_file)
+        if 'open_ended_question' not in df.columns:
+            raise RuntimeError(
+                f"The file {latest_file.name} has no 'open_ended_question' column. "
+                f"Re-run 'generate-open-ended-questions'."
+            )
+
+        rows_by_qid = {}
+        for _, row in df.iterrows():
+            qid = row.get('question_id')
+            if pd.notna(qid):
+                rows_by_qid[int(qid)] = row.to_dict()
+        return rows_by_qid
+
+    def _saveFollowUpManifest(self, messages, question_id, question_mode, subject_str, dry_run):
+        """Save a CSV manifest of follow-up messages sent (or previewed in dry-run)."""
+        from datetime import datetime
+        sent_at = datetime.utcnow().isoformat() + 'Z'
+        manifest_rows = []
+        for student_id, student_name, _, reason in messages:
+            manifest_rows.append({
+                'student_id': student_id,
+                'student_name': student_name,
+                'question_id': question_id,
+                'question_mode': question_mode,
+                'conversation_subject': subject_str,
+                'sent_at': sent_at,
+            })
+
+        manifest_df = pd.DataFrame(manifest_rows)
+        suffix = "_dryrun" if dry_run else ""
+        csv_name = self.config.data_path / (
+            f"{self.config.quiz_prefix}{self.canvas_quiz.id}_followup_sent{suffix}_{today_str()}.csv"
+        )
+        manifest_df.to_csv(csv_name, index=False)
+        print(f"  Manifest saved: {csv_name.name}")
+        logger.info(f"Follow-up manifest saved: {csv_name}")
+
     SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 
     def _spin(self, frame, message, indent=2):

--- a/canvigator_quiz.py
+++ b/canvigator_quiz.py
@@ -536,35 +536,30 @@ class CanvigatorQuiz:
             message_str = f"Hello {first_name}, {reminder}"
             messages.append((student_id, student_name, message_str, reason))
 
-        self._sendOrPreviewMessages(messages, subject_str, quiz_name, points_possible, dry_run)
+        if dry_run:
+            self._sendOrPreviewMessages(messages, subject_str, quiz_name, points_possible)
+        else:
+            self._interactiveSend(messages, subject_str, quiz_name, points_possible)
 
-    def _sendOrPreviewMessages(self, messages, subject_str, quiz_name, points_possible, dry_run):
-        """Send or preview the collected reminder messages and print a summary."""
+    def _sendOrPreviewMessages(self, messages, subject_str, quiz_name, points_possible):
+        """Preview the collected messages in dry-run mode and print a summary."""
         if not messages:
             print("No reminders to send — all students have perfect scores with no page blur events!")
             return
 
-        if dry_run:
-            print("\n=== DRY RUN MODE - No messages will be sent on Canvas ===\n")
+        print("\n=== DRY RUN MODE - No messages will be sent on Canvas ===\n")
 
         print(f"Quiz: {quiz_name} ({points_possible} points possible)")
         print(f"Reminders to send: {len(messages)}\n")
 
         for student_id, student_name, message_str, reason in messages:
-            if dry_run:
-                print(f"  [DRY RUN] To: {student_name} (id: {student_id}, {reason})")
-                print(f"            Subject: {subject_str}")
-                print(f"            Message: {message_str}\n")
-            else:
-                self.canvas.create_conversation(
-                    [str(student_id)], message_str, subject=subject_str, force_new=True
-                )
-                print(f"  Sent to: {student_name} (id: {student_id}, {reason})")
+            print(f"  [DRY RUN] To: {student_name} (id: {student_id}, {reason})")
+            print(f"            Subject: {subject_str}")
+            print(f"            Message: {message_str}\n")
 
         n_no_attempt = sum(1 for _, _, _, r in messages if r == "no attempt")
         n_blur = sum(1 for _, _, _, r in messages if r == "page blur")
         n_imperfect = len(messages) - n_no_attempt - n_blur
-        action = "would be sent" if dry_run else "sent"
         summary_parts = []
         if n_no_attempt:
             summary_parts.append(f"{n_no_attempt} no-attempt")
@@ -572,8 +567,8 @@ class CanvigatorQuiz:
             summary_parts.append(f"{n_imperfect} imperfect-score")
         if n_blur:
             summary_parts.append(f"{n_blur} page-blur")
-        print(f"\n{len(messages)} reminder(s) {action} ({', '.join(summary_parts)}).")
-        logger.info(f"Quiz reminders {'(dry run) ' if dry_run else ''}{action}: {len(messages)} for {quiz_name}")
+        print(f"\n{len(messages)} reminder(s) would be sent ({', '.join(summary_parts)}).")
+        logger.info(f"Quiz reminders (dry run) would be sent: {len(messages)} for {quiz_name}")
 
     def sendFollowUpQuestions(self, dry_run=False):
         """Send the most-missed open-ended follow-up question to students who missed it.
@@ -668,26 +663,26 @@ class CanvigatorQuiz:
             messages.append((student_id, student_name, message_str, f"missed Q{position}"))
 
         if dry_run:
-            self._sendOrPreviewMessages(messages, subject_str, quiz_name, self.canvas_quiz.points_possible, dry_run)
+            self._sendOrPreviewMessages(messages, subject_str, quiz_name, self.canvas_quiz.points_possible)
             self._saveFollowUpManifest(messages, most_missed_qid, question_mode, subject_str, dry_run)
         else:
-            sent_messages = self._interactiveSendFollowUps(messages, subject_str, quiz_name, self.canvas_quiz.points_possible)
+            sent_messages = self._interactiveSend(messages, subject_str, quiz_name, self.canvas_quiz.points_possible)
             if sent_messages:
                 self._saveFollowUpManifest(sent_messages, most_missed_qid, question_mode, subject_str, dry_run)
 
-    def _interactiveSendFollowUps(self, messages, subject_str, quiz_name, points_possible):
-        """Interactively prompt the instructor to send or skip each follow-up message.
+    def _interactiveSend(self, messages, subject_str, quiz_name, points_possible):
+        """Interactively prompt the instructor to send or skip each message.
 
         For each student, displays the message preview and asks the instructor
         to type 'send' or 'skip' (default: skip). Returns the list of messages
         that were actually sent.
         """
         if not messages:
-            print("No follow-up messages to send — all students scored perfectly!")
+            print("No messages to send!")
             return []
 
         print(f"\nQuiz: {quiz_name} ({points_possible} points possible)")
-        print(f"Follow-up messages to review: {len(messages)}")
+        print(f"Messages to review: {len(messages)}")
         print("For each student, enter 'send' to send or press Enter to skip.\n")
 
         sent_messages = []
@@ -709,8 +704,8 @@ class CanvigatorQuiz:
 
         n_sent = len(sent_messages)
         n_skipped = len(messages) - n_sent
-        print(f"\n{n_sent} follow-up(s) sent, {n_skipped} skipped.")
-        logger.info(f"Follow-up questions interactive send: {n_sent} sent, {n_skipped} skipped for {quiz_name}")
+        print(f"\n{n_sent} message(s) sent, {n_skipped} skipped.")
+        logger.info(f"Interactive send for {quiz_name}: {n_sent} sent, {n_skipped} skipped")
         return sent_messages
 
     def _findMostMissedQuestion(self, subs_by_q_df, question_info):

--- a/test_canvigator.py
+++ b/test_canvigator.py
@@ -860,3 +860,110 @@ class TestBuildOpenEndedPrompt:
         from canvigator_llm import _build_open_ended_prompt
         result = _build_open_ended_prompt("", "", None, "explain")
         assert "Oral explanation question" in result
+
+
+# ---------------------------------------------------------------------------
+# canvigator_quiz: follow-up question helper tests
+# ---------------------------------------------------------------------------
+
+def _make_subs_by_question_df(rows):
+    """Build a DataFrame matching the all_subs_by_question schema."""
+    return pd.DataFrame(rows, columns=['name', 'id', 'attempt', 'question', 'question_id', 'points', 'points_possible', 'correct'])
+
+
+def _make_quiz_stub():
+    """Create a minimal mock object with the methods _findMostMissedQuestion and _findStudentsWhoMissed."""
+    from canvigator_quiz import CanvigatorQuiz
+    # We only need the unbound methods — call them with an explicit self=None
+    # since they don't use self at all (only their arguments).
+    return CanvigatorQuiz
+
+
+class TestFindMostMissedQuestion:
+    """Tests for CanvigatorQuiz._findMostMissedQuestion."""
+
+    def _call(self, subs_rows, question_info):
+        """Helper to call _findMostMissedQuestion without a full quiz instance."""
+        cls = _make_quiz_stub()
+        df = _make_subs_by_question_df(subs_rows)
+        return cls._findMostMissedQuestion(None, df, question_info)
+
+    def test_returns_most_missed(self):
+        """Question with higher miss rate is returned."""
+        question_info = {
+            100: {'position': 1, 'keywords': 'topic a', 'points_possible': 1.0},
+            200: {'position': 2, 'keywords': 'topic b', 'points_possible': 1.0},
+        }
+        rows = [
+            ('A', 1, 1, 1, 100, 1.0, 1.0, True),   # student 1 got Q100 right
+            ('A', 1, 1, 2, 200, 0.0, 1.0, False),   # student 1 missed Q200
+            ('B', 2, 1, 1, 100, 0.0, 1.0, False),   # student 2 missed Q100
+            ('B', 2, 1, 2, 200, 0.0, 1.0, False),   # student 2 missed Q200
+        ]
+        result = self._call(rows, question_info)
+        assert result == 200  # both students missed Q200, only one missed Q100
+
+    def test_returns_none_when_all_perfect(self):
+        """Returns None when no questions are missed."""
+        question_info = {
+            100: {'position': 1, 'keywords': 'topic a', 'points_possible': 1.0},
+        }
+        rows = [
+            ('A', 1, 1, 1, 100, 1.0, 1.0, True),
+            ('B', 2, 1, 1, 100, 1.0, 1.0, True),
+        ]
+        result = self._call(rows, question_info)
+        assert result is None
+
+    def test_uses_latest_attempt(self):
+        """Only the latest attempt per student counts toward miss rate."""
+        question_info = {
+            100: {'position': 1, 'keywords': 'topic a', 'points_possible': 1.0},
+        }
+        rows = [
+            # Student 1: missed on attempt 1, got it right on attempt 2
+            ('A', 1, 1, 1, 100, 0.0, 1.0, False),
+            ('A', 1, 2, 1, 100, 1.0, 1.0, True),
+        ]
+        result = self._call(rows, question_info)
+        assert result is None  # latest attempt is perfect
+
+
+class TestFindStudentsWhoMissed:
+    """Tests for CanvigatorQuiz._findStudentsWhoMissed."""
+
+    def _call(self, question_id, subs_rows, question_info):
+        """Helper to call _findStudentsWhoMissed without a full quiz instance."""
+        cls = _make_quiz_stub()
+        df = _make_subs_by_question_df(subs_rows)
+        return cls._findStudentsWhoMissed(None, question_id, df, question_info)
+
+    def test_returns_students_who_missed(self):
+        """Only students who scored below points_possible are returned."""
+        question_info = {100: {'position': 1, 'keywords': 'topic a', 'points_possible': 1.0}}
+        rows = [
+            ('A', 1, 1, 1, 100, 0.0, 1.0, False),
+            ('B', 2, 1, 1, 100, 1.0, 1.0, True),
+            ('C', 3, 1, 1, 100, 0.5, 1.0, False),
+        ]
+        result = self._call(100, rows, question_info)
+        assert sorted(result) == [1, 3]
+
+    def test_uses_latest_attempt(self):
+        """Student who fixed the question on a later attempt is excluded."""
+        question_info = {100: {'position': 1, 'keywords': 'topic a', 'points_possible': 1.0}}
+        rows = [
+            ('A', 1, 1, 1, 100, 0.0, 1.0, False),
+            ('A', 1, 2, 1, 100, 1.0, 1.0, True),
+        ]
+        result = self._call(100, rows, question_info)
+        assert result == []
+
+    def test_empty_when_no_misses(self):
+        """Returns empty list when all students scored perfectly."""
+        question_info = {100: {'position': 1, 'keywords': 'topic a', 'points_possible': 1.0}}
+        rows = [
+            ('A', 1, 1, 1, 100, 1.0, 1.0, True),
+        ]
+        result = self._call(100, rows, question_info)
+        assert result == []

--- a/test_canvigator.py
+++ b/test_canvigator.py
@@ -967,3 +967,82 @@ class TestFindStudentsWhoMissed:
         ]
         result = self._call(100, rows, question_info)
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# canvigator_quiz: reply extraction tests
+# ---------------------------------------------------------------------------
+
+class TestExtractStudentReplies:
+    """Tests for CanvigatorQuiz._extractStudentReplies."""
+
+    def _call(self, messages, instructor_id, sent_at, cutoff):
+        """Helper to call _extractStudentReplies without a full quiz instance."""
+        from canvigator_quiz import CanvigatorQuiz
+        return CanvigatorQuiz._extractStudentReplies(None, messages, instructor_id, sent_at, cutoff)
+
+    def _make_times(self):
+        """Return (sent_at, cutoff) spanning a 5-day window for testing."""
+        from datetime import datetime, timedelta, timezone
+        sent = datetime(2026, 4, 10, 12, 0, 0, tzinfo=timezone.utc)
+        cutoff = sent + timedelta(days=5)
+        return sent, cutoff
+
+    def test_filters_instructor_messages(self):
+        """Messages from the instructor are excluded."""
+        sent, cutoff = self._make_times()
+        messages = [
+            {'id': 1, 'author_id': 999, 'body': 'instructor msg', 'created_at': '2026-04-11T10:00:00Z'},
+            {'id': 2, 'author_id': 42, 'body': 'student reply', 'created_at': '2026-04-11T10:00:00Z'},
+        ]
+        result = self._call(messages, instructor_id=999, sent_at=sent, cutoff=cutoff)
+        assert len(result) == 1
+        assert result[0]['author_id'] == 42
+
+    def test_filters_messages_before_sent_at(self):
+        """Messages created before the follow-up was sent are excluded."""
+        sent, cutoff = self._make_times()
+        messages = [
+            {'id': 1, 'author_id': 42, 'body': 'old msg', 'created_at': '2026-04-09T10:00:00Z'},
+        ]
+        result = self._call(messages, instructor_id=999, sent_at=sent, cutoff=cutoff)
+        assert len(result) == 0
+
+    def test_filters_messages_after_cutoff(self):
+        """Messages created after the reply window closes are excluded."""
+        sent, cutoff = self._make_times()
+        messages = [
+            {'id': 1, 'author_id': 42, 'body': 'late msg', 'created_at': '2026-04-20T10:00:00Z'},
+        ]
+        result = self._call(messages, instructor_id=999, sent_at=sent, cutoff=cutoff)
+        assert len(result) == 0
+
+    def test_includes_messages_within_window(self):
+        """Messages within the reply window from a student are included."""
+        sent, cutoff = self._make_times()
+        messages = [
+            {'id': 1, 'author_id': 42, 'body': 'reply 1', 'created_at': '2026-04-12T10:00:00Z'},
+            {'id': 2, 'author_id': 42, 'body': 'reply 2', 'created_at': '2026-04-13T10:00:00Z'},
+        ]
+        result = self._call(messages, instructor_id=999, sent_at=sent, cutoff=cutoff)
+        assert len(result) == 2
+
+    def test_skips_generated_messages(self):
+        """System-generated messages are excluded."""
+        sent, cutoff = self._make_times()
+        messages = [
+            {'id': 1, 'author_id': 42, 'body': 'auto', 'created_at': '2026-04-11T10:00:00Z', 'generated': True},
+        ]
+        result = self._call(messages, instructor_id=999, sent_at=sent, cutoff=cutoff)
+        assert len(result) == 0
+
+    def test_preserves_newest_first_order(self):
+        """Canvas returns messages newest-first; this order is preserved."""
+        sent, cutoff = self._make_times()
+        messages = [
+            {'id': 2, 'author_id': 42, 'body': 'newer', 'created_at': '2026-04-13T10:00:00Z'},
+            {'id': 1, 'author_id': 42, 'body': 'older', 'created_at': '2026-04-11T10:00:00Z'},
+        ]
+        result = self._call(messages, instructor_id=999, sent_at=sent, cutoff=cutoff)
+        assert result[0]['id'] == 2
+        assert result[1]['id'] == 1

--- a/test_canvigator.py
+++ b/test_canvigator.py
@@ -1046,3 +1046,94 @@ class TestExtractStudentReplies:
         result = self._call(messages, instructor_id=999, sent_at=sent, cutoff=cutoff)
         assert result[0]['id'] == 2
         assert result[1]['id'] == 1
+
+
+# ---------------------------------------------------------------------------
+# canvigator_llm: assessment helper tests
+# ---------------------------------------------------------------------------
+
+class TestParseAssessment:
+    """Tests for canvigator_llm._parse_assessment."""
+
+    def test_parses_pass(self):
+        """Correctly parses a pass result with feedback."""
+        from canvigator_llm import _parse_assessment
+        result, feedback = _parse_assessment("Result: pass\nFeedback: Good explanation of the concept.")
+        assert result == 'pass'
+        assert feedback == 'Good explanation of the concept.'
+
+    def test_parses_fail(self):
+        """Correctly parses a fail result with feedback."""
+        from canvigator_llm import _parse_assessment
+        result, feedback = _parse_assessment("Result: fail\nFeedback: The student did not address the question.")
+        assert result == 'fail'
+        assert feedback == 'The student did not address the question.'
+
+    def test_defaults_to_fail_on_empty(self):
+        """Returns fail with default feedback on empty input."""
+        from canvigator_llm import _parse_assessment
+        result, feedback = _parse_assessment("")
+        assert result == 'fail'
+
+    def test_defaults_to_fail_on_none(self):
+        """Returns fail with default feedback on None input."""
+        from canvigator_llm import _parse_assessment
+        result, feedback = _parse_assessment(None)
+        assert result == 'fail'
+
+    def test_case_insensitive_result(self):
+        """Result parsing is case-insensitive."""
+        from canvigator_llm import _parse_assessment
+        result, feedback = _parse_assessment("Result: Pass\nFeedback: OK.")
+        assert result == 'pass'
+
+    def test_unknown_result_defaults_to_fail(self):
+        """Unknown result value defaults to fail."""
+        from canvigator_llm import _parse_assessment
+        result, feedback = _parse_assessment("Result: maybe\nFeedback: Unclear.")
+        assert result == 'fail'
+
+    def test_fallback_uses_whole_response_as_feedback(self):
+        """If no Feedback: line, the whole response becomes feedback."""
+        from canvigator_llm import _parse_assessment
+        result, feedback = _parse_assessment("Result: pass\nThe student did well.")
+        assert result == 'pass'
+        assert 'The student did well' in feedback
+
+
+class TestBuildAssessmentPrompt:
+    """Tests for canvigator_llm._build_assessment_prompt."""
+
+    def test_includes_all_fields(self):
+        """All provided fields appear in the prompt."""
+        from canvigator_llm import _build_assessment_prompt
+        result = _build_assessment_prompt(
+            keywords="neural networks",
+            open_ended_question="Explain backprop.",
+            original_question_text="What is backprop?",
+            transcript="It's a way to compute gradients.",
+        )
+        assert "neural networks" in result
+        assert "Explain backprop." in result
+        assert "What is backprop?" in result
+        assert "It's a way to compute gradients." in result
+
+    def test_omits_empty_fields(self):
+        """Empty or None fields are omitted cleanly."""
+        from canvigator_llm import _build_assessment_prompt
+        result = _build_assessment_prompt(keywords="", open_ended_question="Q?", original_question_text="", transcript=None)
+        assert "Topic keywords" not in result
+        assert "Original quiz question" not in result
+        assert "transcript" not in result.lower()
+        assert "Q?" in result
+
+    def test_works_for_draw_mode(self):
+        """Prompt without transcript is suitable for draw assessments."""
+        from canvigator_llm import _build_assessment_prompt
+        result = _build_assessment_prompt(
+            keywords="binary trees",
+            open_ended_question="Draw a binary search tree.",
+            original_question_text="What is a BST?",
+        )
+        assert "binary trees" in result
+        assert "transcript" not in result.lower()


### PR DESCRIPTION
## Summary
- **send-follow-up-question**: Identifies the single most-missed quiz question, looks up its open-ended counterpart, and sends it via Canvas message to each student who missed it. Supports `--dry-run` and saves a manifest CSV for downstream tasks.
- **get-replies**: Loads the follow-up manifest, searches Canvas conversations for student replies, downloads image/audio attachments, and outputs a replies CSV. Configurable reply window via `--reply-window-days N`.
- **assess-replies**: Uses local LLM (Ollama) to assess student replies — transcribes audio for "explain" mode, directly assesses images for "draw" mode — producing pass/fail + feedback per student.
- **Interactive send/skip mode**: Both `send-follow-up-question` and `send-quiz-reminder` now prompt the instructor per-student with a message preview and `[send/SKIP]` choice (default: skip) when not in `--dry-run` mode, so instructors can selectively send messages.
- New LLM helpers (`_build_assessment_prompt`, `_parse_assessment`) and reply extraction logic (`_extractStudentReplies`) with full unit test coverage (94 tests total).

## Test plan
- [ ] Run `python -m pytest test_canvigator.py -v` — all 94 tests pass
- [ ] Run both flake8 lint commands — clean
- [ ] Verify `--dry-run` on `send-follow-up-question` still previews all messages without prompting
- [ ] Verify `--dry-run` on `send-quiz-reminder` still previews all messages without prompting
- [ ] Run `send-follow-up-question` without `--dry-run` and confirm interactive send/skip prompt appears per student
- [ ] Run `send-quiz-reminder` without `--dry-run` and confirm interactive send/skip prompt appears per student
- [ ] Run full pipeline: `get-quiz-questions --tag` → `generate-open-ended-questions` → `send-follow-up-question` → `get-replies` → `assess-replies`

🤖 Generated with [Claude Code](https://claude.com/claude-code)