### PR TITLE
Add generate-open-ended-questions task with 3 candidates and assessment guides

### DIFF
--- a/canvigator.py
+++ b/canvigator.py
@@ -44,8 +44,6 @@ def _run_quiz_task(task, quiz, dry_run, tag, reply_window_days):
     """Dispatch a quiz-level task to the appropriate method."""
     if task == 'get-quiz-questions':
         quiz.getQuizQuestions(tag=tag)
-    elif task == 'generate-open-ended-questions':
-        quiz.generateOpenEndedQuestions()
     elif task == 'get-replies':
         quiz.getFollowUpReplies(reply_window_days=reply_window_days)
     elif task == 'assess-replies':
@@ -206,11 +204,20 @@ elif task == 'create-quiz':
 elif task == 'get-gradebook':
     course.exportGradebook(canv_config.data_path)
 
+elif task == 'generate-open-ended-questions':
+    # Driven by a pre-selected tagged-questions CSV, not a Canvas quiz
+    tagged_csv = cu.selectCSVFromList(
+        canv_config.data_path,
+        'questions_w_tags',
+        "\nSelect tagged questions CSV (using index in '[ ]'): ",
+    )
+    cq.generateOpenEndedQuestions(tagged_csv)
+
 else:
     # All remaining tasks require quiz selection
     quiz_choice = cu.selectFromList(course_choice.get_quizzes(), "quiz")
     print(f"\nSelected quiz: {quiz_choice.title}")
-    skip = task in ('get-quiz-questions', 'generate-open-ended-questions', 'get-replies', 'assess-replies')
+    skip = task in ('get-quiz-questions', 'get-replies', 'assess-replies')
     quiz = cq.CanvigatorQuiz(canvas, course, quiz_choice, canv_config, verbose=False, skip_student_data=skip)
     _run_quiz_task(task, quiz, dry_run, tag, reply_window_days)
 

--- a/canvigator_llm.py
+++ b/canvigator_llm.py
@@ -95,6 +95,23 @@ _DRAW_SYSTEM_PROMPT = (
     "No preamble, no explanation, no quotation marks."
 )
 
+_ASSESSMENT_GUIDE_SYSTEM_PROMPT = (
+    "You are an expert university instructor writing a short assessment guide for a specific "
+    "open-ended follow-up question. The guide will be used by another instructor (or an AI "
+    "grader) to decide whether a student's response demonstrates a reasonable understanding "
+    "of the concept.\n\n"
+    "Write 2–4 plain-prose sentences (no bullets, no markdown, no headings) that cover:\n"
+    "- For an \"Explain\" question: the key concepts, terms, or keywords the student should "
+    "mention; for a \"Draw\" question: the key elements, labels, or structural relationships "
+    "that should appear in the drawing.\n"
+    "- What a minimally-acceptable passing response looks like — the bar for \"pass\".\n"
+    "- Common misconceptions, wrong framings, or missing pieces that should NOT count as "
+    "passing.\n\n"
+    "Keep it tight and practical — a grader should be able to read it in under 15 seconds. "
+    "Refer to the student as \"the student\". Respond with ONLY the guide text on a single "
+    "paragraph — no preamble, no label, no numbering, no quotation marks."
+)
+
 
 def _strip_html(text):
     """Reduce Canvas HTML question text to plain text suitable for prompting."""
@@ -310,6 +327,53 @@ def generate_open_ended_candidates(row, client, model, mode, n=3):
         return []
 
 
+def _build_assessment_guide_prompt(keywords, original_question_text, answers_json, mode, open_ended_question):
+    """Build the user-side prompt for generating an assessment guide."""
+    clean_text = _strip_html(original_question_text)
+    labels = _answer_labels(answers_json)
+    parts = []
+    if keywords:
+        parts.append(f"Topic keywords: {keywords}")
+    if clean_text:
+        parts.append(f"Original quiz question: {clean_text}")
+    if labels:
+        joined = " | ".join(labels[:6])
+        parts.append(f"Answer choices from the original: {joined}")
+    parts.append(f"Question type: {'draw (hand-drawn diagram)' if mode == 'draw' else 'explain (verbal explanation)'}")
+    parts.append(f"Open-ended question the student will answer: {open_ended_question}")
+    parts.append("Assessment guide:")
+    return "\n".join(parts)
+
+
+def generate_assessment_guide(row, client, model, mode, open_ended_question):
+    """Call the LLM to produce a short assessment guide for one open-ended question."""
+    if not open_ended_question:
+        return ""
+    prompt = _build_assessment_guide_prompt(
+        row.get("keywords"),
+        row.get("question_text"),
+        row.get("answers"),
+        mode,
+        open_ended_question,
+    )
+    try:
+        resp = client.chat(
+            model=model,
+            messages=[
+                {"role": "system", "content": _ASSESSMENT_GUIDE_SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+            options={"temperature": 0.3},
+        )
+        content = resp["message"]["content"].strip()
+        # Collapse any accidental newlines into spaces — guide should be a single paragraph.
+        content = re.sub(r"\s*\n+\s*", " ", content).strip().strip('"\'')
+        return content
+    except Exception as e:
+        logger.warning(f"LLM assessment-guide generation failed for question {row.get('question_id')}: {e}")
+        return ""
+
+
 _TRANSCRIBE_SYSTEM_PROMPT = (
     "You are a transcription assistant. Listen to the audio and produce an accurate, "
     "verbatim transcription of everything the speaker says. Output ONLY the transcription "
@@ -321,6 +385,9 @@ _ASSESS_EXPLAIN_SYSTEM_PROMPT = (
     "Given the original quiz question, the topic keywords, and the student's spoken response "
     "(provided as a transcript), determine whether the student demonstrates a reasonable "
     "understanding of the core concept.\n\n"
+    "If an \"Assessment guide\" is provided in the user message, treat it as the primary "
+    "rubric for deciding pass vs. fail — it was written by the instructor who knows what a "
+    "correct response looks like.\n\n"
     "A \"pass\" means the student demonstrates a reasonable understanding of the core concept, "
     "even if their explanation is imprecise, incomplete, or uses informal language. "
     "A \"fail\" means the student shows a fundamental misunderstanding, did not address the "
@@ -338,6 +405,9 @@ _ASSESS_DRAW_SYSTEM_PROMPT = (
     "Given the original quiz question, the topic keywords, and the student's drawing "
     "(provided as an image), determine whether the drawing demonstrates a reasonable "
     "understanding of the key concepts and relationships.\n\n"
+    "If an \"Assessment guide\" is provided in the user message, treat it as the primary "
+    "rubric for deciding pass vs. fail — it was written by the instructor who knows what a "
+    "correct drawing looks like.\n\n"
     "A \"pass\" means the drawing shows the essential structure or relationships, even if "
     "it is rough, has minor inaccuracies, or is missing non-critical labels. "
     "A \"fail\" means the drawing is fundamentally incorrect, shows the wrong structure, "
@@ -373,7 +443,7 @@ def _parse_assessment(response):
     return result, feedback
 
 
-def _build_assessment_prompt(keywords, open_ended_question, original_question_text, transcript=None):
+def _build_assessment_prompt(keywords, open_ended_question, original_question_text, transcript=None, assessment_guide=None):
     """Build the user-side prompt for assessing a student response."""
     parts = []
     if keywords:
@@ -382,6 +452,8 @@ def _build_assessment_prompt(keywords, open_ended_question, original_question_te
         parts.append(f"Original quiz question: {original_question_text}")
     if open_ended_question:
         parts.append(f"Follow-up question asked: {open_ended_question}")
+    if assessment_guide:
+        parts.append(f"Assessment guide (use this as your primary rubric): {assessment_guide}")
     if transcript:
         parts.append(f"Student's response (transcript): {transcript}")
     return "\n".join(parts)
@@ -404,9 +476,12 @@ def transcribe_audio(audio_path, client, model):
         return ""
 
 
-def assess_explain(transcript, keywords, open_ended_question, original_question_text, client, model):
+def assess_explain(transcript, keywords, open_ended_question, original_question_text, client, model, assessment_guide=None):
     """Assess a student's verbal explanation using the transcript."""
-    prompt = _build_assessment_prompt(keywords, open_ended_question, original_question_text, transcript=transcript)
+    prompt = _build_assessment_prompt(
+        keywords, open_ended_question, original_question_text,
+        transcript=transcript, assessment_guide=assessment_guide,
+    )
     try:
         resp = client.chat(
             model=model,
@@ -422,9 +497,12 @@ def assess_explain(transcript, keywords, open_ended_question, original_question_
         return 'fail', f'Assessment error: {e}'
 
 
-def assess_draw(image_path, keywords, open_ended_question, original_question_text, client, model):
+def assess_draw(image_path, keywords, open_ended_question, original_question_text, client, model, assessment_guide=None):
     """Assess a student's drawing by sending the image to a multimodal model."""
-    prompt = _build_assessment_prompt(keywords, open_ended_question, original_question_text)
+    prompt = _build_assessment_prompt(
+        keywords, open_ended_question, original_question_text,
+        assessment_guide=assessment_guide,
+    )
     try:
         resp = client.chat(
             model=model,
@@ -471,6 +549,7 @@ def assess_replies(replies, question_info_row, model=None, audio_model=None):
     keywords = question_info_row.get('keywords', '')
     oe_question = question_info_row.get('open_ended_question', '')
     orig_text = question_info_row.get('original_question_text', '')
+    assessment_guide = question_info_row.get('assessment_guide', '') or ''
 
     total = len(replies)
     print(f"Assessing {total} student replies with model '{model}'...")
@@ -503,7 +582,10 @@ def assess_replies(replies, question_info_row, model=None, audio_model=None):
                 })
                 continue
             print(" assessing...", end="", flush=True)
-            result, feedback = assess_explain(transcript, keywords, oe_question, orig_text, client, model)
+            result, feedback = assess_explain(
+                transcript, keywords, oe_question, orig_text, client, model,
+                assessment_guide=assessment_guide,
+            )
         else:
             # Draw mode
             image_path = reply.get('attachment_path', '')
@@ -522,7 +604,10 @@ def assess_replies(replies, question_info_row, model=None, audio_model=None):
                 continue
             transcript = ''
             print(" assessing image...", end="", flush=True)
-            result, feedback = assess_draw(image_path, keywords, oe_question, orig_text, client, model)
+            result, feedback = assess_draw(
+                image_path, keywords, oe_question, orig_text, client, model,
+                assessment_guide=assessment_guide,
+            )
 
         from datetime import datetime, timezone
         assessed_at = datetime.now(timezone.utc).isoformat()
@@ -573,15 +658,18 @@ def generate_open_ended_questions(rows, model=None, n=3):
         mode = classify_question_mode(row, client, model)
         print(f" {mode} — generating {n} candidates...", end="", flush=True)
         candidates = generate_open_ended_candidates(row, client, model, mode, n=n)
+        print(f" writing {len([c for c in candidates if c])} assessment guide(s)...", end="", flush=True)
+        guides = [generate_assessment_guide(row, client, model, mode, cand) for cand in candidates]
         print(" done")
 
         if not candidates:
             logger.warning(f"No candidates generated for question {row.get('question_id')}")
 
         # Always emit exactly n rows per question so every group has a predictable shape.
-        padded = (candidates + [''] * n)[:n]
+        padded_candidates = (candidates + [''] * n)[:n]
+        padded_guides = (guides + [''] * n)[:n]
         original_text = _strip_html(row.get('question_text'))
-        for cand in padded:
+        for cand, guide in zip(padded_candidates, padded_guides):
             results.append({
                 'selected_question': 0,
                 'question_id': row.get('question_id'),
@@ -590,6 +678,7 @@ def generate_open_ended_questions(rows, model=None, n=3):
                 'keywords': row.get('keywords'),
                 'question_mode': mode,
                 'open_ended_question': cand,
+                'assessment_guide': guide,
                 'original_question_text': original_text,
             })
     print("Generation complete.")

--- a/canvigator_llm.py
+++ b/canvigator_llm.py
@@ -36,8 +36,8 @@ _CLASSIFY_SYSTEM_PROMPT = (
 
 _EXPLAIN_SYSTEM_PROMPT = (
     "You are an expert university instructor designing oral exam questions. "
-    "Given a topic and details from an existing quiz question, create ONE new open-ended "
-    "question that a student would answer verbally. The question should:\n"
+    "Given a topic and details from an existing quiz question, create THREE distinct "
+    "open-ended questions that a student would answer verbally. Each question should:\n"
     "- Begin with \"Explain\" and require the student to explain a concept or idea clearly "
     "in their own words\n"
     "- Be answerable in under 1 minute of speaking\n"
@@ -46,14 +46,16 @@ _EXPLAIN_SYSTEM_PROMPT = (
     "- Be self-contained (a student should understand what is being asked without seeing "
     "the original quiz question)\n"
     "- NOT be a yes/no question or a question that can be answered in one word\n\n"
-    "Respond with ONLY the question text — no preamble, no numbering, no explanation, "
-    "no quotation marks."
+    "The three questions must cover DIFFERENT angles, framings, or sub-aspects of the concept — "
+    "do not reword the same question three times.\n\n"
+    "Respond with ONLY the three questions, numbered \"1.\", \"2.\", \"3.\", one per line. "
+    "No preamble, no explanation, no quotation marks."
 )
 
 _DRAW_SYSTEM_PROMPT = (
     "You are an expert university instructor designing visual assessment questions. "
-    "Given a topic and details from an existing quiz question, create ONE new question "
-    "that asks a student to draw a diagram or figure by hand. The question should:\n"
+    "Given a topic and details from an existing quiz question, create THREE distinct "
+    "questions that ask a student to draw a diagram or figure by hand. Each question should:\n"
     "- Begin with \"Draw a diagram\" or \"Draw a figure\" and clearly describe what the "
     "student should illustrate\n"
     "- Be completable in under 2 minutes of drawing\n"
@@ -61,8 +63,10 @@ _DRAW_SYSTEM_PROMPT = (
     "- Be self-contained (a student should understand what is being asked without seeing "
     "the original quiz question)\n"
     "- Specify what key elements or labels should appear in the diagram\n\n"
-    "Respond with ONLY the question text — no preamble, no numbering, no explanation, "
-    "no quotation marks."
+    "The three questions must cover DIFFERENT angles, framings, or sub-aspects of the concept — "
+    "do not reword the same question three times.\n\n"
+    "Respond with ONLY the three questions, numbered \"1.\", \"2.\", \"3.\", one per line. "
+    "No preamble, no explanation, no quotation marks."
 )
 
 
@@ -181,6 +185,20 @@ def tag_questions(rows, model=None):
     print("Tagging complete.")
 
 
+def _parse_candidates(response, n=3):
+    """Parse up to n candidate questions from a numbered LLM response."""
+    if not response:
+        return []
+    candidates = []
+    for line in response.strip().splitlines():
+        stripped = re.sub(r'^\s*(?:\d+[\.\)]|[-*])\s+', '', line).strip().strip("\"'")
+        if stripped:
+            candidates.append(stripped)
+        if len(candidates) == n:
+            break
+    return candidates
+
+
 def _parse_question_mode(response):
     """Parse the classify response into 'explain' or 'draw', defaulting to 'explain'."""
     if not response:
@@ -249,8 +267,8 @@ def classify_question_mode(row, client, model):
         return "explain"
 
 
-def generate_open_ended_question(row, client, model, mode):
-    """Call the LLM to generate one open-ended question of the given mode (explain or draw)."""
+def generate_open_ended_candidates(row, client, model, mode, n=3):
+    """Call the LLM to generate n candidate open-ended questions of the given mode."""
     prompt = _build_open_ended_prompt(
         row.get("keywords"),
         row.get("question_text"),
@@ -268,12 +286,10 @@ def generate_open_ended_question(row, client, model, mode):
             options={"temperature": 0.7},
         )
         content = resp["message"]["content"].strip()
-        # Take only the first paragraph in case the model over-generates
-        first_para = content.split("\n\n")[0].strip()
-        return first_para
+        return _parse_candidates(content, n=n)
     except Exception as e:
         logger.warning(f"LLM generation failed for question {row.get('question_id')}: {e}")
-        return ""
+        return []
 
 
 _TRANSCRIBE_SYSTEM_PROMPT = (
@@ -509,12 +525,15 @@ def assess_replies(replies, question_info_row, model=None, audio_model=None):
     return results
 
 
-def generate_open_ended_questions(rows, model=None):
-    """Classify then generate an open-ended question for each row; returns a list of result dicts.
+def generate_open_ended_questions(rows, model=None, n=3):
+    """Classify and generate n candidate open-ended questions per input row.
 
     Step 1: For each question, ask the LLM whether 'explain' or 'draw' is the
     better assessment mode based on the topic and question content.
-    Step 2: Generate the open-ended question using the mode-specific prompt.
+    Step 2: Generate n candidate open-ended questions using the mode-specific prompt.
+    Returns a flat list of result dicts — n rows per input row (padded with empty
+    candidate strings if the LLM returned fewer). Each row has selected_question=0;
+    the instructor reviews the output CSV and sets one row per group to 1.
     """
     try:
         import ollama
@@ -536,23 +555,32 @@ def generate_open_ended_questions(rows, model=None):
         ) from e
 
     total = len(rows)
-    print(f"Generating {total} open-ended questions with model '{model}'...")
+    print(f"Generating {n} candidate open-ended questions for each of {total} questions with model '{model}'...")
     results = []
     for i, row in enumerate(rows, start=1):
         label = row.get('question_name') or row.get('question_id')
         print(f"  [{i}/{total}] {label} — classifying...", end="", flush=True)
         mode = classify_question_mode(row, client, model)
-        print(f" {mode} — generating...", end="", flush=True)
-        question = generate_open_ended_question(row, client, model, mode)
+        print(f" {mode} — generating {n} candidates...", end="", flush=True)
+        candidates = generate_open_ended_candidates(row, client, model, mode, n=n)
         print(" done")
-        results.append({
-            'question_id': row.get('question_id'),
-            'position': row.get('position'),
-            'question_name': row.get('question_name'),
-            'keywords': row.get('keywords'),
-            'question_mode': mode,
-            'original_question_text': _strip_html(row.get('question_text')),
-            'open_ended_question': question,
-        })
+
+        if not candidates:
+            logger.warning(f"No candidates generated for question {row.get('question_id')}")
+
+        # Always emit exactly n rows per question so every group has a predictable shape.
+        padded = (candidates + [''] * n)[:n]
+        original_text = _strip_html(row.get('question_text'))
+        for cand in padded:
+            results.append({
+                'selected_question': 0,
+                'question_id': row.get('question_id'),
+                'position': row.get('position'),
+                'question_name': row.get('question_name'),
+                'keywords': row.get('keywords'),
+                'question_mode': mode,
+                'open_ended_question': cand,
+                'original_question_text': original_text,
+            })
     print("Generation complete.")
     return results

--- a/canvigator_llm.py
+++ b/canvigator_llm.py
@@ -9,6 +9,10 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_MODEL = os.environ.get("OLLAMA_MODEL", "gemma4:31b")
 DEFAULT_AUDIO_MODEL = os.environ.get("OLLAMA_AUDIO_MODEL", "gemma4:e4b")
+# Used for instructor-side text tasks that never see student data (tagging quiz
+# questions, generating open-ended follow-up questions). A larger cloud model
+# is the better fit here since privacy constraints don't apply.
+DEFAULT_TEXT_MODEL = os.environ.get("OLLAMA_TEXT_MODEL", "gemini-3-flash-preview")
 
 _TAG_SYSTEM_PROMPT = (
     "You are a concise topic tagger for university quiz questions. "
@@ -165,7 +169,7 @@ def tag_questions(rows, model=None):
             "The 'ollama' package is required for --tag. Install with: pip install ollama"
         ) from e
 
-    model = model or DEFAULT_MODEL
+    model = model or DEFAULT_TEXT_MODEL
     client = ollama.Client()
 
     try:
@@ -543,7 +547,7 @@ def generate_open_ended_questions(rows, model=None, n=3):
             "Install with: pip install ollama"
         ) from e
 
-    model = model or DEFAULT_MODEL
+    model = model or DEFAULT_TEXT_MODEL
     client = ollama.Client()
 
     try:

--- a/canvigator_llm.py
+++ b/canvigator_llm.py
@@ -14,6 +14,28 @@ DEFAULT_AUDIO_MODEL = os.environ.get("OLLAMA_AUDIO_MODEL", "gemma4:e4b")
 # is the better fit here since privacy constraints don't apply.
 DEFAULT_TEXT_MODEL = os.environ.get("OLLAMA_TEXT_MODEL", "gemini-3-flash-preview")
 
+# Cloud host for Ollama's hosted models. Used when OLLAMA_API_KEY is set, since
+# models like gemini-3-flash-preview are not available on a local Ollama server.
+OLLAMA_CLOUD_HOST = "https://ollama.com"
+
+
+def _make_client(cloud=False):
+    """Build an ollama.Client — cloud=True points at ollama.com with OLLAMA_API_KEY."""
+    import ollama
+    if cloud:
+        api_key = os.environ.get("OLLAMA_API_KEY")
+        if not api_key:
+            raise RuntimeError(
+                "OLLAMA_API_KEY is required for cloud-hosted text models. "
+                "Re-run ./configure.sh (or add `export OLLAMA_API_KEY=...` to set_env.sh) and re-source."
+            )
+        return ollama.Client(
+            host=OLLAMA_CLOUD_HOST,
+            headers={"Authorization": "Bearer " + api_key},
+        )
+    return ollama.Client()
+
+
 _TAG_SYSTEM_PROMPT = (
     "You are a concise topic tagger for university quiz questions. "
     "Given a question, respond with 1 to 3 short concept tags that describe "
@@ -163,25 +185,17 @@ def tag_question(row, client, model):
 def tag_questions(rows, model=None):
     """Annotate each row dict in-place with a 'tags' key (comma-separated string)."""
     try:
-        import ollama
+        import ollama  # noqa: F401
     except ImportError as e:
         raise RuntimeError(
             "The 'ollama' package is required for --tag. Install with: pip install ollama"
         ) from e
 
     model = model or DEFAULT_TEXT_MODEL
-    client = ollama.Client()
-
-    try:
-        client.list()
-    except Exception as e:
-        raise RuntimeError(
-            f"Could not reach Ollama at its configured host ({os.environ.get('OLLAMA_HOST', 'http://localhost:11434')}). "
-            f"Is the Ollama server running? Original error: {e}"
-        ) from e
+    client = _make_client(cloud=True)
 
     total = len(rows)
-    print(f"Tagging {total} questions with model '{model}'...")
+    print(f"Tagging {total} questions with cloud model '{model}'...")
     for i, row in enumerate(rows, start=1):
         print(f"  [{i}/{total}] {row.get('question_name') or row.get('question_id')}")
         tags = tag_question(row, client, model)
@@ -435,7 +449,7 @@ def assess_replies(replies, question_info_row, model=None, audio_model=None):
     question_info_row should have: keywords, open_ended_question, original_question_text.
     """
     try:
-        import ollama
+        import ollama  # noqa: F401
     except ImportError as e:
         raise RuntimeError(
             "The 'ollama' package is required for assess-replies. "
@@ -444,7 +458,7 @@ def assess_replies(replies, question_info_row, model=None, audio_model=None):
 
     model = model or DEFAULT_MODEL
     audio_model = audio_model or DEFAULT_AUDIO_MODEL
-    client = ollama.Client()
+    client = _make_client(cloud=False)
 
     try:
         client.list()
@@ -540,7 +554,7 @@ def generate_open_ended_questions(rows, model=None, n=3):
     the instructor reviews the output CSV and sets one row per group to 1.
     """
     try:
-        import ollama
+        import ollama  # noqa: F401
     except ImportError as e:
         raise RuntimeError(
             "The 'ollama' package is required for generate-open-ended-questions. "
@@ -548,18 +562,10 @@ def generate_open_ended_questions(rows, model=None, n=3):
         ) from e
 
     model = model or DEFAULT_TEXT_MODEL
-    client = ollama.Client()
-
-    try:
-        client.list()
-    except Exception as e:
-        raise RuntimeError(
-            f"Could not reach Ollama at its configured host ({os.environ.get('OLLAMA_HOST', 'http://localhost:11434')}). "
-            f"Is the Ollama server running? Original error: {e}"
-        ) from e
+    client = _make_client(cloud=True)
 
     total = len(rows)
-    print(f"Generating {n} candidate open-ended questions for each of {total} questions with model '{model}'...")
+    print(f"Generating {n} candidate open-ended questions for each of {total} questions with cloud model '{model}'...")
     results = []
     for i, row in enumerate(rows, start=1):
         label = row.get('question_name') or row.get('question_id')

--- a/canvigator_quiz.py
+++ b/canvigator_quiz.py
@@ -12,6 +12,7 @@ import seaborn as sbn
 import os
 import re
 import json
+from pathlib import Path
 from canvigator_utils import today_str, selectCSVFromList, prompt_for_index
 
 logger = logging.getLogger(__name__)
@@ -146,6 +147,49 @@ def _collect_timing_and_blurs(student_events, timing_by_q, blurs_by_q):
             blur_count = 0
 
 
+def generateOpenEndedQuestions(tagged_csv_path):
+    """Generate open-ended questions from a *_questions_w_tags_*.csv.
+
+    For each original quiz question, asks the LLM to classify the follow-up mode
+    and produce 3 candidate open-ended questions, then prompts the instructor to
+    pick one. The chosen question is saved to a *_open_ended_YYYYMMDD.csv next
+    to the input file.
+    """
+    tagged_csv_path = Path(tagged_csv_path)
+    marker = "_questions_w_tags_"
+    if marker not in tagged_csv_path.name:
+        raise ValueError(
+            f"Expected filename containing '{marker}', got: {tagged_csv_path.name}"
+        )
+    prefix = tagged_csv_path.name.split(marker)[0] + "_"
+
+    df = pd.read_csv(tagged_csv_path)
+    if 'keywords' not in df.columns:
+        raise RuntimeError(
+            f"The file {tagged_csv_path.name} has no 'keywords' column. "
+            f"Re-run 'get-quiz-questions --tag' first."
+        )
+
+    rows = df.to_dict('records')
+
+    import canvigator_llm
+    results = canvigator_llm.generate_open_ended_questions(rows)
+
+    out_df = pd.DataFrame(results, columns=[
+        'selected_question', 'question_id', 'position', 'question_name',
+        'keywords', 'question_mode', 'open_ended_question', 'original_question_text',
+    ])
+    csv_name = tagged_csv_path.parent / f"{prefix}open_ended_{today_str()}.csv"
+    out_df.to_csv(csv_name, index=False)
+    print(f"\nSaved {len(results)} candidate rows ({len(rows)} original questions x 3) to {csv_name}")
+    print(
+        "\nNext step: open this CSV and, for each group of 3 candidates sharing a question_id,\n"
+        "set `selected_question` = 1 on the one candidate you want to send to students\n"
+        "(leave the other two as 0). Then run `send-follow-up-question`."
+    )
+    logger.info(f"Open-ended questions saved: {csv_name}")
+
+
 class CanvigatorQuiz:
     """A class for one quiz and associated attributes/data."""
 
@@ -274,55 +318,6 @@ class CanvigatorQuiz:
         df.to_csv(csv_name, index=False)
         print(f"Saved {len(rows)} questions to {csv_name}")
         logger.info(f"Quiz questions saved: {csv_name}")
-
-    def generateOpenEndedQuestions(self):
-        """Generate open-ended oral exam questions from the tagged questions CSV.
-
-        Requires that get-quiz-questions --tag has been run first. Reads the
-        tagged questions CSV, sends each question to the LLM, and writes the
-        results to a new CSV for instructor review.
-        """
-        # Reuse _loadQuestionInfo's file-finding logic but we need the full CSV rows
-        file_prefix = f"{self.config.quiz_prefix}{self.canvas_quiz.id}_"
-        tagged_pattern = file_prefix + "questions_w_tags_"
-
-        all_files = os.listdir(self.config.data_path)
-        matching_dates = []
-        for f in all_files:
-            m = re.search(r'(\d{8})\.csv$', f)
-            if m and tagged_pattern in f:
-                matching_dates.append((m.group(1), f))
-
-        if not matching_dates:
-            raise FileNotFoundError(
-                f"No *_questions_w_tags_*.csv found for quiz '{self.quiz_name}'. "
-                f"Run 'python canvigator.py --crn <CRN> --tag get-quiz-questions' first."
-            )
-
-        matching_dates.sort(key=lambda t: t[0])
-        latest_file = self.config.data_path / matching_dates[-1][1]
-        print(f"  Using tagged questions from: {latest_file.name}")
-
-        df = pd.read_csv(latest_file)
-        if 'keywords' not in df.columns:
-            raise RuntimeError(
-                f"The file {latest_file.name} has no 'keywords' column. "
-                f"Re-run 'get-quiz-questions --tag' first."
-            )
-
-        rows = df.to_dict('records')
-
-        import canvigator_llm
-        results = canvigator_llm.generate_open_ended_questions(rows)
-
-        out_df = pd.DataFrame(results, columns=[
-            'question_id', 'position', 'question_name', 'keywords',
-            'question_mode', 'original_question_text', 'open_ended_question',
-        ])
-        csv_name = self.config.data_path / f"{file_prefix}open_ended_{today_str()}.csv"
-        out_df.to_csv(csv_name, index=False)
-        print(f"Saved {len(results)} open-ended questions to {csv_name}")
-        logger.info(f"Open-ended questions saved: {csv_name}")
 
     def _buildMissedBulletsForStudent(self, student_id, subs_by_q_df, question_info):
         """Return the missed-questions bullet section for one student, or None to skip."""
@@ -793,6 +788,33 @@ class CanvigatorQuiz:
                 f"Re-run 'generate-open-ended-questions'."
             )
 
+        if 'selected_question' in df.columns:
+            selected = df[df['selected_question'] == 1]
+            all_qids = {int(q) for q in df['question_id'].dropna().unique()}
+            chosen_qids = {int(q) for q in selected['question_id'].dropna().unique()}
+            missing = all_qids - chosen_qids
+            if missing:
+                logger.warning(
+                    f"{latest_file.name}: no `selected_question` row marked for question_id(s) "
+                    f"{sorted(missing)} — they will be skipped."
+                )
+            dup_qids = selected['question_id'].value_counts()
+            dup_qids = [int(q) for q, c in dup_qids.items() if c > 1]
+            if dup_qids:
+                logger.warning(
+                    f"{latest_file.name}: multiple `selected_question=1` rows for question_id(s) "
+                    f"{sorted(dup_qids)} — the first of each will be used."
+                )
+            rows_by_qid = {}
+            for _, row in selected.iterrows():
+                qid = row.get('question_id')
+                if pd.notna(qid):
+                    qid_int = int(qid)
+                    if qid_int not in rows_by_qid:
+                        rows_by_qid[qid_int] = row.to_dict()
+            return rows_by_qid
+
+        # Legacy format: one row per question_id, no selected_question column.
         rows_by_qid = {}
         for _, row in df.iterrows():
             qid = row.get('question_id')

--- a/canvigator_quiz.py
+++ b/canvigator_quiz.py
@@ -177,7 +177,8 @@ def generateOpenEndedQuestions(tagged_csv_path):
 
     out_df = pd.DataFrame(results, columns=[
         'selected_question', 'question_id', 'position', 'question_name',
-        'keywords', 'question_mode', 'open_ended_question', 'original_question_text',
+        'keywords', 'question_mode', 'open_ended_question', 'assessment_guide',
+        'original_question_text',
     ])
     csv_name = tagged_csv_path.parent / f"{prefix}open_ended_{today_str()}.csv"
     out_df.to_csv(csv_name, index=False)

--- a/configure.sh
+++ b/configure.sh
@@ -20,9 +20,15 @@ read LMSURL
 echo "Enter or paste your Canvas LMS access token here (be careful not to share this with anyone else):"
 read TOKEN
 
+echo "Enter or paste your Ollama API key (used for cloud-hosted text models like gemini-3-flash-preview; leave blank if you only plan to use local Ollama models):"
+read OLLAMAKEY
+
 echo "#!/bin/bash" > "$SETENV"
 echo "export CANVAS_URL=\"$LMSURL\"" >> "$SETENV"
 echo "export CANVAS_TOKEN=\"$TOKEN\"" >> "$SETENV"
+if [[ -n "$OLLAMAKEY" ]]; then
+  echo "export OLLAMA_API_KEY=\"$OLLAMAKEY\"" >> "$SETENV"
+fi
 
 # Restrict permissions so only the owner can read the token
 chmod 600 "$SETENV"

--- a/test_canvigator.py
+++ b/test_canvigator.py
@@ -1211,3 +1211,76 @@ class TestBuildAssessmentPrompt:
         )
         assert "binary trees" in result
         assert "transcript" not in result.lower()
+
+    def test_includes_assessment_guide(self):
+        """Assessment guide, when provided, appears labeled as the primary rubric."""
+        from canvigator_llm import _build_assessment_prompt
+        result = _build_assessment_prompt(
+            keywords="binary search",
+            open_ended_question="Explain the time complexity.",
+            original_question_text="What is O(log n)?",
+            transcript="Binary search halves the search space each step.",
+            assessment_guide="Student should mention halving, log n, and sorted input.",
+        )
+        assert "Assessment guide" in result
+        assert "primary rubric" in result
+        assert "halving, log n, and sorted input" in result
+
+    def test_omits_empty_assessment_guide(self):
+        """Empty/None assessment_guide doesn't add a stray label."""
+        from canvigator_llm import _build_assessment_prompt
+        result = _build_assessment_prompt(
+            keywords="k",
+            open_ended_question="Q",
+            original_question_text="O",
+            transcript="t",
+            assessment_guide="",
+        )
+        assert "Assessment guide" not in result
+
+
+class TestBuildAssessmentGuidePrompt:
+    """Tests for canvigator_llm._build_assessment_guide_prompt."""
+
+    def test_includes_all_fields_explain(self):
+        """Keywords, original question, mode, and open-ended question all appear."""
+        from canvigator_llm import _build_assessment_guide_prompt
+        result = _build_assessment_guide_prompt(
+            keywords="recursion, base case",
+            original_question_text="<p>What is a base case?</p>",
+            answers_json=None,
+            mode="explain",
+            open_ended_question="Explain why every recursive function needs a base case.",
+        )
+        assert "recursion, base case" in result
+        assert "What is a base case?" in result  # HTML stripped
+        assert "explain" in result
+        assert "Explain why every recursive function needs a base case." in result
+        assert "Assessment guide:" in result
+
+    def test_draw_mode_label(self):
+        """Draw mode is labeled in the prompt."""
+        from canvigator_llm import _build_assessment_guide_prompt
+        result = _build_assessment_guide_prompt(
+            keywords="linked list",
+            original_question_text="What is a linked list?",
+            answers_json=None,
+            mode="draw",
+            open_ended_question="Draw a diagram of a singly-linked list with 3 nodes.",
+        )
+        assert "draw" in result
+        assert "Draw a diagram of a singly-linked list with 3 nodes." in result
+
+    def test_includes_answer_choices(self):
+        """Answer labels from the original question appear in the prompt."""
+        import json
+        from canvigator_llm import _build_assessment_guide_prompt
+        answers = json.dumps([{"text": "O(1)"}, {"text": "O(log n)"}, {"text": "O(n)"}])
+        result = _build_assessment_guide_prompt(
+            keywords="big-o",
+            original_question_text="What is the complexity?",
+            answers_json=answers,
+            mode="explain",
+            open_ended_question="Explain the complexity.",
+        )
+        assert "O(log n)" in result

--- a/test_canvigator.py
+++ b/test_canvigator.py
@@ -863,6 +863,80 @@ class TestBuildOpenEndedPrompt:
 
 
 # ---------------------------------------------------------------------------
+# canvigator_llm._parse_candidates tests
+# ---------------------------------------------------------------------------
+
+class TestParseCandidates:
+    """Tests for _parse_candidates numbered-response parser."""
+
+    def test_empty_and_none(self):
+        """Empty string or None returns an empty list."""
+        from canvigator_llm import _parse_candidates
+        assert _parse_candidates("") == []
+        assert _parse_candidates(None) == []
+
+    def test_numbered_dot_prefix(self):
+        """Parses '1.' / '2.' / '3.' numbered output."""
+        from canvigator_llm import _parse_candidates
+        resp = "1. Explain recursion.\n2. Explain the base case.\n3. Explain stack frames."
+        assert _parse_candidates(resp) == [
+            "Explain recursion.",
+            "Explain the base case.",
+            "Explain stack frames.",
+        ]
+
+    def test_numbered_paren_prefix(self):
+        """Parses '1)' / '2)' / '3)' style numbering."""
+        from canvigator_llm import _parse_candidates
+        resp = "1) First question?\n2) Second question?\n3) Third question?"
+        assert _parse_candidates(resp) == [
+            "First question?",
+            "Second question?",
+            "Third question?",
+        ]
+
+    def test_bulleted_prefix(self):
+        """Parses '- ' and '* ' bulleted lines."""
+        from canvigator_llm import _parse_candidates
+        resp = "- first\n* second\n- third"
+        assert _parse_candidates(resp) == ["first", "second", "third"]
+
+    def test_strips_surrounding_quotes(self):
+        """Surrounding single/double quotes are stripped."""
+        from canvigator_llm import _parse_candidates
+        resp = '1. "Explain A."\n2. \'Explain B.\'\n3. Explain C.'
+        assert _parse_candidates(resp) == ["Explain A.", "Explain B.", "Explain C."]
+
+    def test_skips_blank_lines(self):
+        """Blank lines between candidates are dropped."""
+        from canvigator_llm import _parse_candidates
+        resp = "1. One\n\n2. Two\n\n\n3. Three"
+        assert _parse_candidates(resp) == ["One", "Two", "Three"]
+
+    def test_truncates_to_n(self):
+        """Only the first n candidates are returned."""
+        from canvigator_llm import _parse_candidates
+        resp = "1. a\n2. b\n3. c\n4. d\n5. e"
+        assert _parse_candidates(resp, n=3) == ["a", "b", "c"]
+
+    def test_no_prefix_each_line_is_candidate(self):
+        """Plain lines without numbering are still treated as candidates."""
+        from canvigator_llm import _parse_candidates
+        resp = "Explain one thing.\nExplain another thing.\nExplain a third thing."
+        assert _parse_candidates(resp) == [
+            "Explain one thing.",
+            "Explain another thing.",
+            "Explain a third thing.",
+        ]
+
+    def test_fewer_than_n_candidates(self):
+        """Returns whatever was generated even if fewer than n."""
+        from canvigator_llm import _parse_candidates
+        resp = "1. Only one."
+        assert _parse_candidates(resp) == ["Only one."]
+
+
+# ---------------------------------------------------------------------------
 # canvigator_quiz: follow-up question helper tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **3-candidate generation:** For each quiz question, the LLM now generates 3 distinct open-ended candidate questions (different angles/framings). The instructor selects one per question by setting `selected_question=1` in the output CSV (`*_open_ended_YYYYMMDD.csv`).
- **Cloud model routing:** Instructor-side text tasks (`get-quiz-questions --tag`, `generate-open-ended-questions`) route to `gemini-3-flash-preview` via the Ollama cloud endpoint (`https://ollama.com`), authenticated with `OLLAMA_API_KEY`. Student-data tasks (`assess-replies`) stay on local `gemma4:31b`/`gemma4:e4b`.
- **Assessment guides:** Gemini generates a short assessment guide per candidate question — key concepts/elements a passing response must include. Stored in a new `assessment_guide` CSV column (between `open_ended_question` and `original_question_text`); flows through to `assess-replies` as the primary rubric for gemma4.
- **Local CSV selection:** `generate-open-ended-questions` now selects from `*_questions_w_tags_*.csv` files already on disk rather than prompting for a Canvas quiz — only quizzes that have been tagged are shown.
- **`configure.sh` update:** Prompts for `OLLAMA_API_KEY` and writes it to `set_env.sh`.

## Test plan

- [ ] Run `flake8` linting passes clean
- [ ] Run `python -m pytest test_canvigator.py -v` — 108 tests pass
- [ ] End-to-end: `python canvigator.py --crn <CRN> generate-open-ended-questions` shows tagged CSV list, displays 3 candidates per question, writes `*_open_ended_YYYYMMDD.csv` with `assessment_guide` column
- [ ] Run `send-follow-up-question --dry-run` against the new CSV to confirm schema compatibility
- [ ] Run `assess-replies` and confirm assessment guide appears in the LLM prompt and improves grading

🤖 Generated with [Claude Code](https://claude.com/claude-code)