### PR TITLE
Cleanup: datetime, merge keys, find-latest-CSV helper, and --all flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,10 @@ each other. By default this uses the cloud-hosted text model
 to be set — see [Ollama setup](#ollama-setup-optional). The model can be
 overridden via `OLLAMA_TEXT_MODEL`.
 
+Pass `--all` to skip the interactive quiz prompt and export every quiz in the
+selected course — one CSV per quiz, using each quiz's own filename prefix.
+`--all` and `--tag` can be used independently or together.
+
 ---
 
 #### `get-replies` — Retrieve student replies to follow-up questions

--- a/canvigator.py
+++ b/canvigator.py
@@ -23,10 +23,11 @@ tasks = list(task_descriptions.keys())
 
 def print_help():
     """Print usage information with task descriptions."""
-    print("Usage: canvigator.py [--dry-run] [--tag] [--crn <CRN>] <task>\n")
+    print("Usage: canvigator.py [--dry-run] [--tag] [--all] [--crn <CRN>] <task>\n")
     print("Options:")
     print("  --dry-run      Preview changes without modifying Canvas (bonus, reminder, and follow-up tasks)")
     print("  --tag          Use a local LLM via Ollama to tag questions (get-quiz-questions only)")
+    print("  --all          Run across every quiz in the course instead of prompting for one (get-quiz-questions only)")
     print("  --crn <CRN>    Select course by CRN (last 5 digits of course code)")
     print("  --reply-window-days N  Days to accept replies after follow-up sent (default: 5, get-replies only)\n")
     print("Tasks:")
@@ -77,6 +78,10 @@ if dry_run:
 tag = '--tag' in args
 if tag:
     args.remove('--tag')
+
+all_quizzes_flag = '--all' in args
+if all_quizzes_flag:
+    args.remove('--all')
 
 crn = None
 if '--crn' in args:
@@ -212,6 +217,14 @@ elif task == 'generate-open-ended-questions':
         "\nSelect tagged questions CSV (using index in '[ ]'): ",
     )
     cq.generateOpenEndedQuestions(tagged_csv)
+
+elif task == 'get-quiz-questions' and all_quizzes_flag:
+    all_course_quizzes = list(course_choice.get_quizzes())
+    print(f"\nFound {len(all_course_quizzes)} quiz(zes).")
+    for i, q in enumerate(all_course_quizzes, start=1):
+        print(f"\n[{i}/{len(all_course_quizzes)}] {q.title}")
+        quiz = cq.CanvigatorQuiz(canvas, course, q, canv_config, verbose=False, skip_student_data=True)
+        quiz.getQuizQuestions(tag=tag)
 
 else:
     # All remaining tasks require quiz selection

--- a/canvigator_quiz.py
+++ b/canvigator_quiz.py
@@ -825,8 +825,8 @@ class CanvigatorQuiz:
 
     def _saveFollowUpManifest(self, messages, question_id, question_mode, subject_str, dry_run):
         """Save a CSV manifest of follow-up messages sent (or previewed in dry-run)."""
-        from datetime import datetime
-        sent_at = datetime.utcnow().isoformat() + 'Z'
+        from datetime import datetime, timezone
+        sent_at = datetime.now(timezone.utc).isoformat()
         manifest_rows = []
         for student_id, student_name, _, reason in messages:
             manifest_rows.append({
@@ -1317,7 +1317,7 @@ class CanvigatorQuiz:
         self.df_present = df_present_all[df_present_all['present'] == 1]
         print(f"  *** (double check there are {len(self.df_present)} students present today) ***")
 
-        self.df_quiz_scores_present = pd.merge(self.df_present[['name', 'id']], self.quiz_df, how='left')
+        self.df_quiz_scores_present = pd.merge(self.df_present[['name', 'id']], self.quiz_df.drop(columns=['name'], errors='ignore'), on='id', how='left')
         # replace missing vals with zero (for people who missed pre-quiz)
         with pd.option_context("future.no_silent_downcasting", True):
             self.df_quiz_scores_present = self.df_quiz_scores_present.fillna(0).infer_objects(copy=False)

--- a/canvigator_quiz.py
+++ b/canvigator_quiz.py
@@ -13,7 +13,7 @@ import os
 import re
 import json
 from pathlib import Path
-from canvigator_utils import today_str, selectCSVFromList, prompt_for_index
+from canvigator_utils import today_str, selectCSVFromList, prompt_for_index, find_latest_csv
 
 logger = logging.getLogger(__name__)
 
@@ -408,21 +408,12 @@ class CanvigatorQuiz:
         file_prefix = f"{self.config.quiz_prefix}{self.canvas_quiz.id}_"
         tagged_pattern = file_prefix + "questions_w_tags_"
 
-        all_files = os.listdir(self.config.data_path)
-        matching_dates = []
-        for f in all_files:
-            m = re.search(r'(\d{8})\.csv$', f)
-            if m and tagged_pattern in f:
-                matching_dates.append((m.group(1), f))
-
-        if not matching_dates:
+        latest_file = find_latest_csv(self.config.data_path, tagged_pattern)
+        if latest_file is None:
             raise FileNotFoundError(
                 f"No *_questions_w_tags_*.csv found for quiz '{self.quiz_name}'. "
                 f"Run 'python canvigator.py --crn <CRN> --tag get-quiz-questions' first."
             )
-
-        matching_dates.sort(key=lambda t: t[0])
-        latest_file = self.config.data_path / matching_dates[-1][1]
         print(f"  Using question data from: {latest_file.name}")
         dc_df = pd.read_csv(latest_file)
 
@@ -765,21 +756,12 @@ class CanvigatorQuiz:
         file_prefix = f"{self.config.quiz_prefix}{self.canvas_quiz.id}_"
         oe_pattern = file_prefix + "open_ended_"
 
-        all_files = os.listdir(self.config.data_path)
-        matching_dates = []
-        for f in all_files:
-            m = re.search(r'(\d{8})\.csv$', f)
-            if m and oe_pattern in f:
-                matching_dates.append((m.group(1), f))
-
-        if not matching_dates:
+        latest_file = find_latest_csv(self.config.data_path, oe_pattern)
+        if latest_file is None:
             raise FileNotFoundError(
                 f"No *_open_ended_*.csv found for quiz '{self.quiz_name}'. "
                 f"Run 'python canvigator.py generate-open-ended-questions' first."
             )
-
-        matching_dates.sort(key=lambda t: t[0])
-        latest_file = self.config.data_path / matching_dates[-1][1]
         print(f"  Using open-ended questions from: {latest_file.name}")
 
         df = pd.read_csv(latest_file)
@@ -966,24 +948,12 @@ class CanvigatorQuiz:
         file_prefix = f"{self.config.quiz_prefix}{self.canvas_quiz.id}_"
         manifest_pattern = file_prefix + "followup_sent_"
 
-        all_files = os.listdir(self.config.data_path)
-        matching_dates = []
-        for f in all_files:
-            # Skip dryrun manifests
-            if '_dryrun_' in f:
-                continue
-            m = re.search(r'(\d{8})\.csv$', f)
-            if m and manifest_pattern in f:
-                matching_dates.append((m.group(1), f))
-
-        if not matching_dates:
+        latest_file = find_latest_csv(self.config.data_path, manifest_pattern, exclude_substr='_dryrun_')
+        if latest_file is None:
             raise FileNotFoundError(
                 f"No *_followup_sent_*.csv found for quiz '{self.quiz_name}'. "
                 f"Run 'send-follow-up-question' first."
             )
-
-        matching_dates.sort(key=lambda t: t[0])
-        latest_file = self.config.data_path / matching_dates[-1][1]
         print(f"  Using follow-up manifest: {latest_file.name}")
 
         df = pd.read_csv(latest_file)
@@ -1136,21 +1106,12 @@ class CanvigatorQuiz:
         file_prefix = f"{self.config.quiz_prefix}{self.canvas_quiz.id}_"
         replies_pattern = file_prefix + "followup_replies_"
 
-        all_files = os.listdir(self.config.data_path)
-        matching_dates = []
-        for f in all_files:
-            m = re.search(r'(\d{8})\.csv$', f)
-            if m and replies_pattern in f:
-                matching_dates.append((m.group(1), f))
-
-        if not matching_dates:
+        latest_file = find_latest_csv(self.config.data_path, replies_pattern)
+        if latest_file is None:
             raise FileNotFoundError(
                 f"No *_followup_replies_*.csv found for quiz '{self.quiz_name}'. "
                 f"Run 'get-replies' first."
             )
-
-        matching_dates.sort(key=lambda t: t[0])
-        latest_file = self.config.data_path / matching_dates[-1][1]
         print(f"  Using replies from: {latest_file.name}")
         return pd.read_csv(latest_file)
 

--- a/canvigator_utils.py
+++ b/canvigator_utils.py
@@ -45,6 +45,28 @@ def prompt_for_index(prompt_msg, max_index):
         return index - 1
 
 
+def find_latest_csv(data_path, pattern, exclude_substr=None):
+    """Return the Path of the newest CSV in data_path whose name contains `pattern` and ends with _YYYYMMDD.csv.
+
+    Files whose name contains `exclude_substr` (if given) are skipped — used to
+    exclude dry-run artifacts from sent-manifest lookups. Returns None when no
+    matching file exists so the caller can raise a task-specific FileNotFoundError.
+    """
+    matches = []
+    for f in os.listdir(data_path):
+        if exclude_substr and exclude_substr in f:
+            continue
+        m = re.search(r'(\d{8})\.csv$', f)
+        if m and pattern in f:
+            matches.append((m.group(1), f))
+
+    if not matches:
+        return None
+
+    matches.sort(key=lambda t: t[0])
+    return Path(data_path) / matches[-1][1]
+
+
 def selectCSVFromList(directory, keyword, prompt_msg, verbose=False):
     """
     List CSV files in directory matching keyword, prompt user to select one,


### PR DESCRIPTION
## Summary
- Replace deprecated `datetime.utcnow()` with timezone-aware `datetime.now(timezone.utc)`, and fix `openPresentCSV` merge to join on `id` only (was silently dropping students on any `name` mismatch).
- Factor the repeated "find newest `<pattern>_YYYYMMDD.csv` in data dir" loop out of four loaders into a shared `canvigator_utils.find_latest_csv` helper (no behavior change).
- Add `--all` flag to `get-quiz-questions` that iterates every quiz in the course instead of prompting for one; composes with `--tag` (either, both, or neither).

## Test plan
- [x] `python -m pytest test_canvigator.py -v` — 108 passed
- [x] Both CI flake8 invocations clean
- [x] `python canvigator.py --help` shows the new `--all` option
- [ ] Manual: run `python canvigator.py --crn <CRN> --all get-quiz-questions` against a real course and confirm one CSV per quiz
- [ ] Manual: run with `--all --tag` combined and confirm `*_questions_w_tags_*.csv` per quiz

🤖 Generated with [Claude Code](https://claude.com/claude-code)