### PR TITLE
Conversation task improvements, histogram fixes, and CLI short flags

### DIFF
--- a/canvigator.py
+++ b/canvigator.py
@@ -25,6 +25,7 @@ task_groups = [
         ('get-activity', 'Export student activity data'),
         ('get-quiz-submission-events', 'Export quiz submissions and events for a selected quiz (use --all for every quiz)'),
         ('get-conversations', 'Export Canvas conversations involving students in the selected course'),
+        ('delete-old-conversations', 'Delete Canvas conversations older than N months (account-wide; default 6, override with --m; use --dry-run first)'),
         ('get-gradebook', 'Export course gradebook'),
         ('get-roster', 'Export the full course roster (name, id, sis_id, enrollment_type)'),
         ('send-quiz-reminder', 'Send quiz reminder messages to students'),
@@ -36,12 +37,13 @@ tasks = list(task_descriptions.keys())
 
 def print_help():
     """Print usage information with grouped task descriptions."""
-    print("Usage: canvigator.py [--dry-run] [--tag] [--all] [--crn <CRN>] <task>\n")
+    print("Usage: canvigator.py [--dry-run] [--tag] [--all] [--crn <CRN>] [--m <months>] <task>\n")
     print("Options:")
-    print("  --dry-run      Preview changes without modifying Canvas (bonus, reminder, follow-up, and feedback tasks)")
+    print("  --dry-run      Preview changes without modifying Canvas (bonus, reminder, follow-up, feedback, and delete-old-conversations tasks)")
     print("  --tag          Use a cloud LLM via Ollama to tag questions (get-quiz-questions only)")
     print("  --all          Run across every quiz in the course instead of prompting for one (get-quiz-questions and get-quiz-submission-events only)")
     print("  --crn <CRN>    Select course by CRN (last 5 digits of course code)")
+    print("  --m <months>   Age threshold in months for delete-old-conversations (default: 6)")
     print("  --reply-window-days N  Days to accept replies after follow-up sent (default: 5, assess-replies only)")
     max_name = max(len(t) for t in tasks)
     for header, items in task_groups:
@@ -114,6 +116,22 @@ if '--crn' in args:
     args.pop(crn_idx)  # remove '--crn'
     args.pop(crn_idx)  # remove the CRN value
 
+n_months = 6
+if '--m' in args:
+    m_idx = args.index('--m')
+    if m_idx + 1 >= len(args):
+        print("Error: --m requires a numeric value (number of months)")
+        sys.exit(1)
+    try:
+        n_months = int(args[m_idx + 1])
+        if n_months < 1:
+            raise ValueError
+    except ValueError:
+        print(f"Error: --m must be a positive integer, got '{args[m_idx + 1]}'")
+        sys.exit(1)
+    args.pop(m_idx)  # remove '--m'
+    args.pop(m_idx)  # remove the value
+
 reply_window_days = 5
 if '--reply-window-days' in args:
     rw_idx = args.index('--reply-window-days')
@@ -179,6 +197,28 @@ if task == 'export-anon-data':
 
     print(f"\nSelected: {course_data_path.name}")
     cc.exportAnonymizedData(course_data_path)
+    print("\n*** Done ***\n")
+    sys.exit(0)
+
+# delete-old-conversations is account-wide (Canvas conversations aren't course-scoped)
+if task == 'delete-old-conversations':
+    import os
+    import logging
+    import canvasapi
+    import canvigator_utils as cu
+    import canvigator_course as cc
+
+    cu.setup_logging()
+    logger = logging.getLogger(__name__)
+
+    API_URL = os.environ.get("CANVAS_URL")
+    API_KEY = os.environ.get("CANVAS_TOKEN")
+    if not API_URL or not API_KEY:
+        print("Error: CANVAS_URL and CANVAS_TOKEN must be set. Run 'source set_env.sh' first.")
+        sys.exit(1)
+
+    canvas = canvasapi.Canvas(API_URL, API_KEY)
+    cc.deleteOldConversations(canvas, dry_run=dry_run, max_age_months=n_months)
     print("\n*** Done ***\n")
     sys.exit(0)
 

--- a/canvigator.py
+++ b/canvigator.py
@@ -25,7 +25,7 @@ task_groups = [
         ('get-activity', 'Export student activity data'),
         ('get-quiz-submission-events', 'Export quiz submissions and events for a selected quiz (use --all for every quiz)'),
         ('get-conversations', 'Export Canvas conversations involving students in the selected course'),
-        ('delete-old-conversations', 'Delete Canvas conversations older than N months (account-wide; default 6, override with --m; use --dry-run first)'),
+        ('delete-old-conversations', 'Delete Canvas conversations older than N months (account-wide; default 6; override with --months/-m)'),
         ('get-gradebook', 'Export course gradebook'),
         ('get-roster', 'Export the full course roster (name, id, sis_id, enrollment_type)'),
         ('send-quiz-reminder', 'Send quiz reminder messages to students'),
@@ -37,14 +37,14 @@ tasks = list(task_descriptions.keys())
 
 def print_help():
     """Print usage information with grouped task descriptions."""
-    print("Usage: canvigator.py [--dry-run] [--tag] [--all] [--crn <CRN>] [--m <months>] <task>\n")
-    print("Options:")
-    print("  --dry-run      Preview changes without modifying Canvas (bonus, reminder, follow-up, feedback, and delete-old-conversations tasks)")
-    print("  --tag          Use a cloud LLM via Ollama to tag questions (get-quiz-questions only)")
-    print("  --all          Run across every quiz in the course instead of prompting for one (get-quiz-questions and get-quiz-submission-events only)")
-    print("  --crn <CRN>    Select course by CRN (last 5 digits of course code)")
-    print("  --m <months>   Age threshold in months for delete-old-conversations (default: 6)")
-    print("  --reply-window-days N  Days to accept replies after follow-up sent (default: 5, assess-replies only)")
+    print("Usage: canvigator.py [OPTIONS] <task>\n")
+    print("Options (short and long forms are interchangeable):")
+    print("  -d, --dry-run                Preview changes without modifying Canvas (applies to bonus, reminder, follow-up, feedback, delete-old-conversations)")
+    print("  -t, --tag                    Use a cloud LLM via Ollama to tag questions (get-quiz-questions only)")
+    print("  -a, --all                    Run across every quiz in the course (get-quiz-questions and get-quiz-submission-events only)")
+    print("  -c, --crn <CRN>              Select course by CRN (last 5 digits of course code)")
+    print("  -m, --months <N>             Age threshold in months for delete-old-conversations (default: 6)")
+    print("  -w, --reply-window-days <N>  Days to accept replies after follow-up sent (default: 5, assess-replies only)")
     max_name = max(len(t) for t in tasks)
     for header, items in task_groups:
         print(f"\n{header}")
@@ -90,7 +90,18 @@ def _run_quiz_task(task, quiz, dry_run, tag, reply_window_days):
         quiz.awardBonusPoints(dry_run=dry_run)
 
 
-args = sys.argv[1:]
+# Normalize short flag aliases to their long form so the rest of the parser
+# can match a single canonical name per option.
+_SHORT_TO_LONG = {
+    '-d': '--dry-run',
+    '-t': '--tag',
+    '-a': '--all',
+    '-c': '--crn',
+    '-m': '--months',
+    '-w': '--reply-window-days',
+}
+args = [_SHORT_TO_LONG.get(a, a) for a in sys.argv[1:]]
+
 dry_run = '--dry-run' in args
 if dry_run:
     args.remove('--dry-run')
@@ -107,7 +118,7 @@ crn = None
 if '--crn' in args:
     crn_idx = args.index('--crn')
     if crn_idx + 1 >= len(args):
-        print("Error: --crn requires a 5-digit CRN value")
+        print("Error: --crn/-c requires a 5-digit CRN value")
         sys.exit(1)
     crn = args[crn_idx + 1]
     if not crn.isdigit() or len(crn) != 5:
@@ -117,33 +128,33 @@ if '--crn' in args:
     args.pop(crn_idx)  # remove the CRN value
 
 n_months = 6
-if '--m' in args:
-    m_idx = args.index('--m')
+if '--months' in args:
+    m_idx = args.index('--months')
     if m_idx + 1 >= len(args):
-        print("Error: --m requires a numeric value (number of months)")
+        print("Error: --months/-m requires a numeric value (number of months)")
         sys.exit(1)
     try:
         n_months = int(args[m_idx + 1])
         if n_months < 1:
             raise ValueError
     except ValueError:
-        print(f"Error: --m must be a positive integer, got '{args[m_idx + 1]}'")
+        print(f"Error: --months/-m must be a positive integer, got '{args[m_idx + 1]}'")
         sys.exit(1)
-    args.pop(m_idx)  # remove '--m'
+    args.pop(m_idx)  # remove '--months'
     args.pop(m_idx)  # remove the value
 
 reply_window_days = 5
 if '--reply-window-days' in args:
     rw_idx = args.index('--reply-window-days')
     if rw_idx + 1 >= len(args):
-        print("Error: --reply-window-days requires a numeric value")
+        print("Error: --reply-window-days/-w requires a numeric value")
         sys.exit(1)
     try:
         reply_window_days = int(args[rw_idx + 1])
         if reply_window_days < 1:
             raise ValueError
     except ValueError:
-        print(f"Error: --reply-window-days must be a positive integer, got '{args[rw_idx + 1]}'")
+        print(f"Error: --reply-window-days/-w must be a positive integer, got '{args[rw_idx + 1]}'")
         sys.exit(1)
     args.pop(rw_idx)  # remove '--reply-window-days'
     args.pop(rw_idx)  # remove the value

--- a/canvigator_course.py
+++ b/canvigator_course.py
@@ -5,7 +5,7 @@ from collections import Counter
 from datetime import datetime, timedelta, timezone
 import pandas as pd
 import canvigator_quiz as cq
-from canvigator_utils import today_str
+from canvigator_utils import today_str, spin, spin_done
 
 MAX_COURSE_WEEKS = 16
 
@@ -140,8 +140,19 @@ class CanvigatorCourse:
         assess-replies on older sends).
 
         Output columns: conversation_id, subject, last_message_at,
-        message_count, workflow_state, student_ids, student_names,
-        n_student_participants, last_message.
+        first_message_at, message_count, workflow_state, student_ids,
+        student_names, n_student_participants, last_message.
+
+        ``first_message_at`` is derived by fetching each matched conversation
+        and taking the earliest ``created_at`` across its messages. When
+        ``last_message_at`` is missing (occasionally empty on the list
+        endpoint for older/archived threads), ``first_message_at`` is used in
+        its place so sorting stays meaningful.
+
+        Conversations whose ``last_message_at`` predates the course start
+        date are excluded — prior-term threads would otherwise pollute the
+        back-fill. The start date is read from ``course.get_settings()``
+        (key ``start_date``), falling back to ``course.start_at``.
         """
         student_ids = {s['id'] for s in self.students}
         student_names = {s['id']: s['name'] for s in self.students}
@@ -149,14 +160,21 @@ class CanvigatorCourse:
             print("No active students on the course roster — nothing to filter conversations against.")
             return
 
+        course_start_dt = _resolveCourseStart(self.canvas_course)
+        if course_start_dt is None:
+            print("Course has no start date — skipping the pre-course filter.")
+        else:
+            print(f"Course start date: {course_start_dt.date().isoformat()} — older conversations will be excluded.")
+
+        # First pass: collect matched conversations from the list endpoints so the
+        # per-conversation fetch loop (below) can show a sized "N/M" spinner.
+        matched_convos = []
         seen = set()
-        rows = []
         # 'inbox' scope (default) excludes archived; 'sent' is needed for conversations
         # the instructor opened that haven't received a reply (and therefore aren't in
         # the inbox view). Dedupe by conversation_id when scopes overlap.
         for scope in (None, 'sent'):
             label = scope or 'inbox'
-            print(f"Fetching {label} conversations...")
             try:
                 convos = self.canvas.get_conversations(scope=scope) if scope else self.canvas.get_conversations()
                 for c in convos:
@@ -167,27 +185,54 @@ class CanvigatorCourse:
                     matched = [p for p in participants if p.get('id') in student_ids]
                     if not matched:
                         continue
+                    last_at = getattr(c, 'last_message_at', '') or ''
+                    last_dt = _parse_canvas_timestamp(last_at)
+                    if course_start_dt is not None and last_dt is not None and last_dt < course_start_dt:
+                        continue
                     seen.add(cid)
-                    matched_ids = [p['id'] for p in matched]
-                    matched_names = [student_names.get(pid, '') for pid in matched_ids]
-                    rows.append({
-                        'conversation_id': cid,
-                        'subject': getattr(c, 'subject', '') or '',
-                        'last_message_at': getattr(c, 'last_message_at', '') or '',
-                        'message_count': getattr(c, 'message_count', 0),
-                        'workflow_state': getattr(c, 'workflow_state', '') or '',
-                        'student_ids': ','.join(str(i) for i in matched_ids),
-                        'student_names': '; '.join(matched_names),
-                        'n_student_participants': len(matched_ids),
-                        'last_message': (getattr(c, 'last_message', '') or '').strip(),
-                    })
+                    matched_convos.append((c, matched, last_at))
             except Exception as e:
                 logger.warning(f"Failed to fetch conversations with scope={label}: {e}")
                 print(f"  (failed: {e})")
 
+        # Second pass: fetch each matched conversation to derive first_message_at.
+        # This is one extra API call per conversation, so surface progress via spinner.
+        rows = []
+        total = len(matched_convos)
+        skipped_pre_start = 0
+        for idx, (c, matched, last_at) in enumerate(matched_convos, start=1):
+            cid = getattr(c, 'id', None)
+            spin(idx - 1, f"Fetching conversation {idx}/{total} (id={cid})")
+            matched_ids = [p['id'] for p in matched]
+            matched_names = [student_names.get(pid, '') for pid in matched_ids]
+            first_at = _fetchFirstMessageAt(self.canvas, cid)
+            if not last_at:
+                last_at = first_at
+                # Re-check the start-date filter now that we have a timestamp to compare.
+                last_dt = _parse_canvas_timestamp(last_at)
+                if course_start_dt is not None and last_dt is not None and last_dt < course_start_dt:
+                    skipped_pre_start += 1
+                    continue
+            rows.append({
+                'conversation_id': cid,
+                'subject': getattr(c, 'subject', '') or '',
+                'last_message_at': last_at,
+                'first_message_at': first_at,
+                'message_count': getattr(c, 'message_count', 0),
+                'workflow_state': getattr(c, 'workflow_state', '') or '',
+                'student_ids': ','.join(str(i) for i in matched_ids),
+                'student_names': '; '.join(matched_names),
+                'n_student_participants': len(matched_ids),
+                'last_message': (getattr(c, 'last_message', '') or '').strip(),
+            })
+        if total:
+            spin_done(f"Fetched {total} conversation(s).")
+        if skipped_pre_start:
+            print(f"Skipped {skipped_pre_start} conversation(s) older than the course start date.")
+
         df = pd.DataFrame(rows, columns=[
-            'conversation_id', 'subject', 'last_message_at', 'message_count',
-            'workflow_state', 'student_ids', 'student_names',
+            'conversation_id', 'subject', 'last_message_at', 'first_message_at',
+            'message_count', 'workflow_state', 'student_ids', 'student_names',
             'n_student_participants', 'last_message',
         ])
         df = df.sort_values('last_message_at', ascending=False, na_position='last')
@@ -464,6 +509,152 @@ class CanvigatorCourse:
             })
         return pd.DataFrame(rows, columns=['id', 'top_browser', 'top_os',
                                            'used_mobile_app', 'n_distinct_user_agents'])
+
+
+def _collectOldConversations(canvas, cutoff_dt, current_user_id):
+    """Return a list of conversation dicts with last_message_at older than ``cutoff_dt``.
+
+    Sweeps the 'inbox', 'sent', and 'archived' scopes, dedupes by
+    conversation_id, and filters to conversations older than the cutoff.
+    Falls back to ``last_authored_message_at`` when ``last_message_at`` is
+    empty (sent-only threads where the student never replied). Each entry
+    has keys: id, obj, subject, last_message_at, participant_names.
+    """
+    results = []
+    seen = set()
+    scope_counts = {}
+    for scope in (None, 'sent', 'archived'):
+        label = scope or 'inbox'
+        seen_this_scope = 0
+        kept_this_scope = 0
+        try:
+            convos = canvas.get_conversations(scope=scope) if scope else canvas.get_conversations()
+            for c in convos:
+                seen_this_scope += 1
+                cid = getattr(c, 'id', None)
+                if cid is None or cid in seen:
+                    continue
+                # For sent-only conversations (instructor authored the only message), Canvas
+                # often leaves last_message_at empty on the list endpoint and populates
+                # last_authored_message_at instead. Fall back to that so those threads are
+                # still considered.
+                last_at = getattr(c, 'last_message_at', '') or ''
+                if not last_at:
+                    last_at = getattr(c, 'last_authored_message_at', '') or ''
+                last_dt = _parse_canvas_timestamp(last_at)
+                if last_dt is None or last_dt >= cutoff_dt:
+                    continue
+                seen.add(cid)
+                kept_this_scope += 1
+                participants = getattr(c, 'participants', []) or []
+                others = [p for p in participants if p.get('id') != current_user_id]
+                names = '; '.join(p.get('name', '') or str(p.get('id', '')) for p in others)
+                results.append({
+                    'id': cid,
+                    'obj': c,
+                    'subject': getattr(c, 'subject', '') or '',
+                    'last_message_at': last_at,
+                    'participant_names': names,
+                })
+        except Exception as e:
+            logger.warning(f"Failed to fetch conversations with scope={label}: {e}")
+            print(f"  (failed: {e})")
+        scope_counts[label] = (seen_this_scope, kept_this_scope)
+    parts = [f"{label}: {k}/{s} match" for label, (s, k) in scope_counts.items()]
+    print("Scanned — " + "; ".join(parts))
+    return results
+
+
+def deleteOldConversations(canvas, dry_run=False, max_age_months=6):
+    """Delete the instructor's Canvas conversations older than ``max_age_months`` months.
+
+    Canvas conversations are not course-scoped, so this sweeps the instructor's
+    inbox, sent, and archived scopes (deduped by conversation_id) and deletes
+    each conversation whose ``last_message_at`` is at least ``max_age_months``
+    months (approximated as 30 days/month) before today. In dry-run mode, prints the
+    target conversations (last_message_at, subject, participant names) instead
+    of deleting. In live mode, prints the same list and asks for an explicit
+    'yes' confirmation before deleting.
+
+    Uses ``Conversation.delete()`` (``DELETE /api/v1/conversations/:id``) —
+    not ``delete_messages()``, which only removes specific messages.
+    """
+    try:
+        current_user_id = canvas.get_current_user().id
+    except Exception as e:
+        logger.warning(f"Failed to identify current user: {e}")
+        current_user_id = None
+
+    max_age_days = max_age_months * 30
+    cutoff_dt = datetime.now(timezone.utc) - timedelta(days=max_age_days)
+    print(f"Cutoff date: {cutoff_dt.date().isoformat()} "
+          f"(~{max_age_months} month{'s' if max_age_months != 1 else ''}) "
+          f"— conversations with last_message_at before this will be deleted.")
+
+    to_delete = _collectOldConversations(canvas, cutoff_dt, current_user_id)
+
+    total = len(to_delete)
+    if total == 0:
+        print(f"No conversations older than {max_age_months} month(s) found.")
+        return
+
+    to_delete.sort(key=lambda x: x['last_message_at'])
+    action = "Would delete" if dry_run else "Deleting"
+    print(f"\n{action} {total} conversation(s):")
+    for item in to_delete:
+        print(f"  [{item['last_message_at']}] {item['participant_names']} — {item['subject']}")
+
+    if dry_run:
+        print("\n--dry-run: no conversations were deleted.")
+        return
+
+    resp = input(f"\nConfirm deletion of {total} conversation(s)? Type 'yes' to proceed: ").strip().lower()
+    if resp != 'yes':
+        print("Aborted — no conversations deleted.")
+        return
+
+    deleted = 0
+    failed = 0
+    for idx, item in enumerate(to_delete, start=1):
+        spin(idx - 1, f"Deleting conversation {idx}/{total} (id={item['id']})")
+        try:
+            item['obj'].delete()
+            deleted += 1
+        except Exception as e:
+            logger.warning(f"Failed to delete conversation {item['id']}: {e}")
+            failed += 1
+    summary = f"Deleted {deleted} conversation(s)"
+    if failed:
+        summary += f"; {failed} failed (see log)"
+    spin_done(summary + ".")
+
+
+def _resolveCourseStart(canvas_course):
+    """Return the course start as a UTC datetime, or None if unavailable.
+
+    Prefers ``course.get_settings()['start_date']`` (the instructor-set
+    override), falling back to ``course.start_at``.
+    """
+    try:
+        settings = canvas_course.get_settings() or {}
+        dt = _parse_canvas_timestamp(settings.get('start_date'))
+        if dt is not None:
+            return dt
+    except Exception as e:
+        logger.warning(f"course.get_settings() failed: {e}")
+    return _parse_canvas_timestamp(getattr(canvas_course, 'start_at', None))
+
+
+def _fetchFirstMessageAt(canvas, cid):
+    """Return the earliest message ``created_at`` for a conversation, or ''."""
+    try:
+        full = canvas.get_conversation(cid, auto_mark_as_read=False)
+    except Exception as e:
+        logger.warning(f"get_conversation({cid}) failed while computing first_message_at: {e}")
+        return ''
+    messages = getattr(full, 'messages', []) or []
+    timestamps = [m.get('created_at', '') for m in messages if m.get('created_at')]
+    return min(timestamps) if timestamps else ''
 
 
 def _parse_canvas_timestamp(ts_str):

--- a/canvigator_quiz.py
+++ b/canvigator_quiz.py
@@ -3,6 +3,8 @@ import random
 import logging
 import csv
 import requests
+import math
+import numpy as np
 import pandas as pd
 import scipy.spatial.distance as distance
 import matplotlib.pyplot as plt
@@ -37,6 +39,69 @@ def _parse_points_possible_from_student_analysis(csv_path):
         except (TypeError, ValueError):
             continue
     return points_possible
+
+
+def _annotate_stats(ax, mean, std):
+    """Render a small mean/sd text box in the upper-left of a matplotlib axis."""
+    text = f'mean: {_fmt_stat(mean)}\nsd: {_fmt_stat(std)}'
+    ax.text(
+        0.04, 0.96, text,
+        transform=ax.transAxes, va='top', ha='left', fontsize=8,
+        bbox=dict(facecolor='white', alpha=0.75, edgecolor='none', pad=2),
+    )
+
+
+def _fmt_stat(x):
+    """Format a number with at most 2 decimal places, trimming trailing zeros.
+
+    Returns '—' for None or NaN. Examples: 0.5 → '0.5', 0.123 → '0.12',
+    1.0 → '1', 0.0 → '0', None → '—'.
+    """
+    if x is None:
+        return '—'
+    try:
+        if math.isnan(x):
+            return '—'
+    except TypeError:
+        return '—'
+    s = f'{x:.2f}'
+    if '.' in s:
+        s = s.rstrip('0').rstrip('.')
+    return s or '0'
+
+
+def _scoreHistogramBins(max_pts):
+    """Return bin edges for a score histogram with fixed width based on ``max_pts``.
+
+    Width is 0.1 when max_pts ≤ 1.5, 0.2 when ≤ 2.5, 0.5 when > 2.5. Uses
+    ``np.linspace`` (not arange) to avoid float-precision issues at the upper
+    edge. Falls back to ``10`` (a plain bin count) when ``max_pts`` is missing
+    or non-positive.
+    """
+    if not max_pts or max_pts <= 0:
+        return 10
+    if max_pts <= 1.5:
+        width = 0.1
+    elif max_pts <= 2.5:
+        width = 0.2
+    else:
+        width = 0.5
+    n_bins = max(1, round(max_pts / width))
+    return list(np.linspace(0, max_pts, n_bins + 1))
+
+
+def _integerAlignedBins(data_by_q):
+    """Return integer-aligned bin edges covering 0..ceil(overall_max)+1.
+
+    Used by the timing (1-minute) and blur (1-count) histograms so every
+    subplot shares the same x-axis and bar count. Returns ``None`` when
+    there is no data across any question.
+    """
+    all_vals = [v for vals in data_by_q.values() for v in vals]
+    if not all_vals:
+        return None
+    overall_max = max(all_vals)
+    return list(range(0, math.ceil(overall_max) + 2))
 
 
 def _render_missed_bullets(missed_rows, question_info):
@@ -1439,20 +1504,29 @@ class CanvigatorQuiz:
         figure.set_size_inches(13, 3)
         for i, q in enumerate(self.quiz_question_ids):
             score_col = q + '_score'
-            col_data = self.quiz_df[score_col]
-            axis[i].hist(col_data, bins=6, facecolor='#00447c', edgecolor='black', alpha=0.8)
+            col_data = self.quiz_df[score_col].dropna()
+            max_pts = self.question_points_possible.get(int(q))
+            bins = _scoreHistogramBins(max_pts)
+            axis[i].hist(col_data, bins=bins, facecolor='#00447c', edgecolor='black', alpha=0.8)
             axis[i].axvline(col_data.mean(), color='black', linestyle='dashed', linewidth=1)
             axis[i].set_xlabel('score')
-            axis[i].set_title('question: ' + q.split('_')[0])
-        axis[0].set_ylabel('# of people')
+            axis[i].set_title(f'Q{i + 1}')
+            if len(col_data) >= 2:
+                _annotate_stats(axis[i], col_data.mean(), col_data.std())
+        axis[0].set_ylabel('# of students')
         plt.tight_layout()  # Or try plt.subplots_adjust(left=0.05, right=0.98, bottom=0.15, top=0.9)
-        fig_path = self.figurePath("histograms")
+        fig_path = self.figurePath("score_histograms")
         figure.savefig(fig_path, dpi=200)
         plt.close('all')
         print(f"  ✓ Saved: {fig_path.name}")
 
-    def _plotPerQuestionHistogram(self, data_by_q, xlabel, facecolor, figure_name):
-        """Plot a row of per-question histograms and save the figure."""
+    def _plotPerQuestionHistogram(self, data_by_q, xlabel, facecolor, figure_name, bins=None):
+        """Plot a row of per-question histograms and save the figure.
+
+        When ``bins`` is provided (a list of edges), every subplot shares it
+        so bar widths and the x-axis match across questions. Falls back to
+        ``bins=10`` per subplot when ``bins`` is None (e.g., no data at all).
+        """
         question_ids = self.quiz_question_ids
         n_questions = len(question_ids)
         mpl.style.use('seaborn-v0_8')
@@ -1463,9 +1537,11 @@ class CanvigatorQuiz:
         for i, qid in enumerate(question_ids):
             data = data_by_q[qid]
             if data:
-                bins = range(0, max(data) + 2) if all(isinstance(v, int) for v in data) else 10
-                axes[i].hist(data, bins=bins, facecolor=facecolor, edgecolor='black', alpha=0.8)
+                subplot_bins = bins if bins is not None else 10
+                axes[i].hist(data, bins=subplot_bins, facecolor=facecolor, edgecolor='black', alpha=0.8)
                 axes[i].axvline(sum(data) / len(data), color='black', linestyle='dashed', linewidth=1)
+                if len(data) >= 2:
+                    _annotate_stats(axes[i], float(np.mean(data)), float(np.std(data, ddof=1)))
             axes[i].set_xlabel(xlabel)
             axes[i].set_title(f'Q{i + 1}')
         axes[0].set_ylabel('# of students')
@@ -1508,8 +1584,10 @@ class CanvigatorQuiz:
             print("  (No per-question event data available for timing/blur histograms)")
             return
 
-        self._plotPerQuestionHistogram(timing_by_q, 'minutes', '#00447c', 'timing_first_attempt')
-        self._plotPerQuestionHistogram(blurs_by_q, '# of page blurs', '#c44e52', 'blurs_first_attempt')
+        timing_bins = _integerAlignedBins(timing_by_q)
+        blur_bins = _integerAlignedBins(blurs_by_q)
+        self._plotPerQuestionHistogram(timing_by_q, 'minutes', '#00447c', 'timing_first_attempt', bins=timing_bins)
+        self._plotPerQuestionHistogram(blurs_by_q, '# of page blurs', '#c44e52', 'blurs_first_attempt', bins=blur_bins)
 
     def generateDistanceMatrix(self, only_present, distance_type='euclid'):
         """Calculate vector distance between all possible student pairs."""

--- a/canvigator_quiz.py
+++ b/canvigator_quiz.py
@@ -77,20 +77,26 @@ def _render_missed_bullets(missed_rows, question_info):
     return header + "\n".join(lines)
 
 
-def _composeConversationSubject(course_code, quiz_name, suffix):
+def _composeConversationSubject(course_code, quiz_name, suffix, short_code=False):
     """Build a Canvas Conversation subject that includes course identity, quiz, and a per-message suffix.
 
-    The course code is compacted to ``<prefix>-<number>-<CRN>`` by dropping the
-    middle section component when it's present (Canvas codes typically look
-    like ``CSI-3300-001-12345``); shorter codes pass through unchanged. The
-    suffix is the per-message tail (e.g. ``"Q3 Follow-Up"`` or ``"Reminder"``).
-    The richer subject lets students/instructors group conversations across
-    classes, quizzes, and questions; threads themselves are still tracked
-    internally by ``conversation_id``, so subject changes are safe.
+    By default the course code is compacted to ``<prefix>-<number>-<CRN>`` by
+    dropping the middle section component when it's present (Canvas codes
+    typically look like ``CSI-3300-001-12345``); shorter codes pass through
+    unchanged. When ``short_code=True``, the code is further truncated to the
+    portion before the second hyphen (``<prefix>-<number>``), and codes with
+    zero or one hyphen pass through unchanged — used for follow-up question
+    subjects where the CRN is noise. The suffix is the per-message tail (e.g.
+    ``"Q3 Follow-Up"`` or ``"Reminder"``). The richer subject lets
+    students/instructors group conversations across classes, quizzes, and
+    questions; threads themselves are still tracked internally by
+    ``conversation_id``, so subject changes are safe.
     """
     code = str(course_code).strip() if course_code else ''
     code_parts = [p for p in code.split('-') if p]
-    if len(code_parts) == 4:
+    if short_code:
+        code_parts = code_parts[:2]
+    elif len(code_parts) == 4:
         code_parts = [code_parts[0], code_parts[1], code_parts[3]]
     course_label = '-'.join(code_parts) if code_parts else 'Course'
     parts = [course_label, str(quiz_name).strip()]
@@ -690,6 +696,7 @@ class CanvigatorQuiz:
             self.canvas_course.canvas_course.course_code,
             quiz_name,
             f"Q{position} Follow-Up",
+            short_code=True,
         )
         enrolled = self.canvas_course.students
         enrolled_map = {s['id']: s['name'] for s in enrolled}

--- a/test_canvigator.py
+++ b/test_canvigator.py
@@ -1245,6 +1245,102 @@ class TestComposeConversationSubject:
 
 
 # ---------------------------------------------------------------------------
+# canvigator_quiz: histogram bin helpers
+# ---------------------------------------------------------------------------
+
+class TestFmtStat:
+    """Tests for canvigator_quiz._fmt_stat."""
+
+    def test_trims_trailing_zeros(self):
+        """0.50 renders as '0.5', not '0.50'."""
+        from canvigator_quiz import _fmt_stat
+        assert _fmt_stat(0.5) == '0.5'
+
+    def test_caps_at_two_decimals(self):
+        """0.1234 rounds to '0.12'."""
+        from canvigator_quiz import _fmt_stat
+        assert _fmt_stat(0.1234) == '0.12'
+
+    def test_integer_value_drops_decimal(self):
+        """1.0 renders as '1', not '1.0' or '1.00'."""
+        from canvigator_quiz import _fmt_stat
+        assert _fmt_stat(1.0) == '1'
+
+    def test_zero(self):
+        """0.0 renders as '0'."""
+        from canvigator_quiz import _fmt_stat
+        assert _fmt_stat(0.0) == '0'
+
+    def test_nan_and_none(self):
+        """Renders NaN and None as an em-dash placeholder."""
+        from canvigator_quiz import _fmt_stat
+        import math as _m
+        assert _fmt_stat(float('nan')) == '—'
+        assert _fmt_stat(None) == '—'
+        assert _fmt_stat(_m.nan) == '—'
+
+
+class TestScoreHistogramBins:
+    """Tests for canvigator_quiz._scoreHistogramBins."""
+
+    def test_width_0_1_when_max_pts_1(self):
+        """1-point question uses 0.1-wide bins across [0, 1]."""
+        from canvigator_quiz import _scoreHistogramBins
+        bins = _scoreHistogramBins(1.0)
+        assert len(bins) == 11
+        assert bins[0] == 0
+        assert bins[-1] == 1.0
+        assert abs(bins[1] - 0.1) < 1e-9
+
+    def test_width_0_1_at_threshold_1_5(self):
+        """max_pts = 1.5 still uses 0.1-wide bins (≤ 1.5 rule)."""
+        from canvigator_quiz import _scoreHistogramBins
+        bins = _scoreHistogramBins(1.5)
+        assert len(bins) == 16
+
+    def test_width_0_2_when_max_pts_2(self):
+        """2-point question uses 0.2-wide bins."""
+        from canvigator_quiz import _scoreHistogramBins
+        bins = _scoreHistogramBins(2.0)
+        assert len(bins) == 11
+        assert bins[-1] == 2.0
+
+    def test_width_0_5_when_max_pts_3(self):
+        """3-point question uses 0.5-wide bins."""
+        from canvigator_quiz import _scoreHistogramBins
+        bins = _scoreHistogramBins(3.0)
+        assert len(bins) == 7
+        assert bins[-1] == 3.0
+
+    def test_fallback_when_max_pts_missing(self):
+        """None max_pts falls back to the integer bin count 10."""
+        from canvigator_quiz import _scoreHistogramBins
+        assert _scoreHistogramBins(None) == 10
+        assert _scoreHistogramBins(0) == 10
+
+
+class TestIntegerAlignedBins:
+    """Tests for canvigator_quiz._integerAlignedBins."""
+
+    def test_spans_zero_to_ceil_max_plus_one(self):
+        """Edges cover [0, ceil(max)+1] so every integer value has a bucket."""
+        from canvigator_quiz import _integerAlignedBins
+        bins = _integerAlignedBins({'q1': [0, 1, 2], 'q2': [5]})
+        assert bins == [0, 1, 2, 3, 4, 5, 6]
+
+    def test_ceils_float_values(self):
+        """Non-integer timing values round up so the max is covered."""
+        from canvigator_quiz import _integerAlignedBins
+        bins = _integerAlignedBins({'q1': [0.3, 2.7]})
+        assert bins == [0, 1, 2, 3, 4]
+
+    def test_returns_none_when_empty(self):
+        """Empty data across all questions returns None."""
+        from canvigator_quiz import _integerAlignedBins
+        assert _integerAlignedBins({'q1': [], 'q2': []}) is None
+
+
+# ---------------------------------------------------------------------------
 # canvigator_llm: assessment helper tests
 # ---------------------------------------------------------------------------
 

--- a/test_canvigator.py
+++ b/test_canvigator.py
@@ -1193,10 +1193,10 @@ class TestComposeFollowUpFeedbackMessage:
 class TestComposeConversationSubject:
     """Tests for canvigator_quiz._composeConversationSubject."""
 
-    def _call(self, course_code, quiz_name, suffix):
+    def _call(self, course_code, quiz_name, suffix, short_code=False):
         """Invoke the module-level helper."""
         from canvigator_quiz import _composeConversationSubject
-        return _composeConversationSubject(course_code, quiz_name, suffix)
+        return _composeConversationSubject(course_code, quiz_name, suffix, short_code=short_code)
 
     def test_drops_section_from_four_part_code(self):
         """A four-part Canvas code drops the section component (3rd part)."""
@@ -1222,6 +1222,26 @@ class TestComposeConversationSubject:
         """An empty suffix drops the trailing separator instead of leaving a dangling dash."""
         out = self._call('CSI-3300-12345', 'Quiz 1', '')
         assert out == 'CSI-3300-12345 - Quiz 1'
+
+    def test_short_code_truncates_four_part_code(self):
+        """short_code=True truncates CSI-3300-001-12345 to CSI-3300 (up to the second hyphen)."""
+        out = self._call('CSI-3300-001-12345', 'Quiz 1', 'Q3 Follow-Up', short_code=True)
+        assert out == 'CSI-3300 - Quiz 1 - Q3 Follow-Up'
+
+    def test_short_code_truncates_three_part_code(self):
+        """short_code=True truncates CSI-3300-12345 to CSI-3300."""
+        out = self._call('CSI-3300-12345', 'Quiz 2', 'Q1 Follow-Up', short_code=True)
+        assert out == 'CSI-3300 - Quiz 2 - Q1 Follow-Up'
+
+    def test_short_code_preserves_single_hyphen_code(self):
+        """A code with only one hyphen is unchanged (still only two parts)."""
+        out = self._call('MATH-101', 'Quiz 1', 'Q1 Follow-Up', short_code=True)
+        assert out == 'MATH-101 - Quiz 1 - Q1 Follow-Up'
+
+    def test_short_code_preserves_hyphenless_code(self):
+        """A code with no hyphens passes through entirely."""
+        out = self._call('MATH101', 'Quiz 1', 'Q1 Follow-Up', short_code=True)
+        assert out == 'MATH101 - Quiz 1 - Q1 Follow-Up'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three related areas of improvement, one logical commit each:

- **Conversation tasks**: `get-conversations` now includes a `first_message_at` column (derived via a per-conversation fetch with a progress spinner), backfills empty `last_message_at` so the descending sort stays meaningful, and filters out threads older than the course start date (read from `Course.get_settings()['start_date']`, falling back to `course.start_at`). Noisy "Fetching inbox/sent conversations..." prints dropped. Added a new `delete-old-conversations` task that does an account-wide sweep of inbox + sent + archived, falls back to `last_authored_message_at` for instructor-only threads, and deletes via `Conversation.delete()` (not `delete_messages`, which only removes per-message). Configurable age via `--months`/`-m` (default 6 months). `--dry-run` previews; live mode requires typing `yes`. `send-follow-up-question` subjects are also now compacter: new `short_code=True` option truncates the course code to `<prefix>-<number>` (e.g. `CSI-3300`) — dropping the section + CRN — while keeping the quiz name and `Q{n} Follow-Up` suffix.

- **Histograms** (`quiz*_score_histograms_*.png` + timing/blurs): titles use `Q1..QN` instead of raw question_ids; y-axis label is now `# of students`. Bin widths are fixed and comparable across questions — scores use 0.1 / 0.2 / 0.5 based on each question's points_possible (spanning `[0, max_pts]` via `np.linspace`); timing/blurs use integer-aligned edges shared across all subplots so bar widths and counts line up. Every subplot now carries a small upper-left mean/SD annotation with at most 2 decimal places (trailing zeros trimmed). Filename renamed from `quiz*_histograms_*.png` to `quiz*_score_histograms_*.png`.

- **CLI short flags**: every long option gets a single-dash alias — `-d`/`--dry-run`, `-t`/`--tag`, `-a`/`--all`, `-c`/`--crn`, `-m`/`--months` (renamed from `--m`), `-w`/`--reply-window-days`. A small `_SHORT_TO_LONG` table normalizes short → long once up front, so the rest of the parser keeps a single canonical name per option. Help output lists each option as `-x, --xxx` with description; error messages name both forms.

17 new unit tests total (4 short_code + 5 `_fmt_stat` + 5 `_scoreHistogramBins` + 3 `_integerAlignedBins`). All 137 tests pass; flake8 clean on both rule sets.

## Test plan

- [x] `python canvigator.py --help` renders cleanly with `-x, --xxx` option list
- [x] `python canvigator.py -d get-gradebook` (dry-run via short flag) reaches the same path as `--dry-run`
- [x] `python canvigator.py -c <CRN> get-conversations` shows the course-start line, per-conversation spinner, and produces a CSV with a `first_message_at` column
- [x] `python canvigator.py --dry-run delete-old-conversations` lists old conversations across inbox/sent/archived; none deleted
- [x] `python canvigator.py --dry-run -m 3 delete-old-conversations` uses a 3-month cutoff
- [x] `python canvigator.py delete-old-conversations` with "yes" at the prompt deletes listed threads
- [x] `python canvigator.py -c <CRN> send-follow-up-question` produces a subject like `DSML-4220 - <quiz> - Q3 Follow-Up` (no CRN/section)
- [x] `python canvigator.py -c <CRN> get-quiz-submission-events` produces `quiz*_score_histograms_*.png` with Q1..QN titles, fixed-width bars, mean/sd annotations, and shared-bin timing/blur files

🤖 Generated with [Claude Code](https://claude.com/claude-code)