### PR TITLE
Filter send-quiz-reminder to open quizzes; document delete-old-conversations

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,16 +112,17 @@ All model names are overridable via env vars (`OLLAMA_TEXT_MODEL`, `OLLAMA_MODEL
 source set_env.sh                            # set Canvas (and optional Ollama) environment variables (once per terminal session)
 python canvigator.py <task>                  # run a task (prompts for course selection)
 python canvigator.py --crn <CRN> <task>      # select course by CRN (last 5 digits of course code)
-python canvigator.py --dry-run <task>        # preview changes without modifying Canvas (bonus, reminder, and follow-up tasks)
+python canvigator.py --dry-run <task>        # preview changes without modifying Canvas (bonus, reminder, follow-up, and delete-old-conversations tasks)
 python canvigator.py --tag get-quiz-questions     # add LLM-generated topic tags to the quiz questions export
 python canvigator.py --reply-window-days N <task>  # set the days-after-send window for assess-replies (default: 5)
+python canvigator.py --months N delete-old-conversations  # cutoff age in months for delete-old-conversations (default: 6)
 ```
 
 The `--crn` option selects a course by its CRN (the last 5 digits of the Canvas
 course code), bypassing the interactive course selection prompt. This is useful
 for automated/scheduled runs, e.g. `python canvigator.py --crn 12345 get-activity`.
 
-Available tasks: `assess-replies`, `award-bonus`, `award-bonus-partner-only`, `award-bonus-retake-only`, `create-pairs`, `create-quiz`, `export-anon-data`, `generate-follow-up-questions`, `get-activity`, `get-conversations`, `get-gradebook`, `get-quiz-questions`, `get-quiz-submission-events`, `get-roster`, `send-follow-up-assessments`, `send-follow-up-question`, `send-quiz-reminder`
+Available tasks: `assess-replies`, `award-bonus`, `award-bonus-partner-only`, `award-bonus-retake-only`, `create-pairs`, `create-quiz`, `delete-old-conversations`, `export-anon-data`, `generate-follow-up-questions`, `get-activity`, `get-conversations`, `get-gradebook`, `get-quiz-questions`, `get-quiz-submission-events`, `get-roster`, `send-follow-up-assessments`, `send-follow-up-question`, `send-quiz-reminder`
 
 All tasks begin by prompting you to select a course. Output files are written to
 `data/<course>/` and `figures/<course>/`, where `<course>` is derived from the
@@ -516,6 +517,32 @@ The output CSV is sorted newest first and contains columns: `conversation_id`,
 `subject`, `last_message_at`, `message_count`, `workflow_state`, `student_ids`
 (comma-separated), `student_names` (semicolon-separated), `n_student_participants`,
 `last_message`.
+
+---
+
+#### `delete-old-conversations` — Delete inbox conversations older than N months
+
+Sweeps the instructor's Canvas inbox, sent folder, and archived folder for
+conversations whose most recent message is older than `N` months
+(approximate; one month = 30 days, default `N = 6`). Each match is shown
+(last_message_at, subject, participant names) before any action is taken.
+In live mode the task requires an explicit `yes` confirmation at the prompt
+before any deletes run; `--dry-run` previews only.
+
+Canvas conversations are not course-scoped, so this task skips course
+selection entirely and operates on the full account inbox. Deletion uses
+`Conversation.delete()` to remove the whole thread (not just individual
+messages).
+
+Override the cutoff with `--months`/`-m`, e.g.
+`python canvigator.py --months 12 delete-old-conversations` keeps the
+most recent year and deletes everything older.
+
+| | Files |
+|---|---|
+| **Input** | _(none — operates directly against the Canvas inbox)_ |
+| **Output** | _(none — matched conversations are listed in the terminal)_ |
+| **Canvas side-effect** | Permanently deletes matched conversations (skipped in `--dry-run` mode); requires explicit `yes` confirmation in live mode |
 
 ---
 

--- a/canvigator.py
+++ b/canvigator.py
@@ -303,7 +303,14 @@ elif task == 'get-quiz-questions' and all_quizzes_flag:
 
 else:
     # All remaining tasks require quiz selection
-    quiz_choice = cu.selectFromList(course_choice.get_quizzes(), "quiz")
+    all_quizzes = list(course_choice.get_quizzes())
+    if task == 'send-quiz-reminder':
+        candidates = [q for q in all_quizzes if cu.is_quiz_open_for_reminder(q)]
+        if not candidates:
+            raise ValueError("No published quizzes with a future due date were found.")
+    else:
+        candidates = all_quizzes
+    quiz_choice = cu.selectFromList(candidates, "quiz")
     print(f"\nSelected quiz: {quiz_choice.title}")
     skip = task in ('get-quiz-questions', 'assess-replies', 'send-follow-up-assessments')
     quiz = cq.CanvigatorQuiz(canvas, course, quiz_choice, canv_config, verbose=False, skip_student_data=skip)

--- a/canvigator_utils.py
+++ b/canvigator_utils.py
@@ -3,7 +3,7 @@ import re
 import sys
 import logging
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
@@ -146,6 +146,26 @@ def selectFromList(paginated_list, item_type="item"):
     index = prompt_for_index(f"\nSelect {item_type} from above using index in square brackets: ", len(subobject_list) - 1)
     logger.info(f"Selected {item_type} at index {index}: {subobject_list[index]}")
     return subobject_list[index]
+
+
+def is_quiz_open_for_reminder(quiz, now=None):
+    """Return True if quiz is published and has a due_at strictly in the future (UTC).
+
+    Quizzes without a due_at are treated as not open for reminders. `now` is
+    injectable for tests; defaults to datetime.now(timezone.utc).
+    """
+    if not getattr(quiz, 'published', False):
+        return False
+    due_at = getattr(quiz, 'due_at', None)
+    if not due_at:
+        return False
+    try:
+        due_dt = datetime.fromisoformat(due_at.replace('Z', '+00:00'))
+    except (TypeError, ValueError, AttributeError):
+        return False
+    if now is None:
+        now = datetime.now(timezone.utc)
+    return due_dt > now
 
 
 def selectCourseByCRN(canvas, crn):

--- a/test_canvigator.py
+++ b/test_canvigator.py
@@ -103,6 +103,66 @@ class TestPromptForIndex:
         assert result == 0
 
 
+class _StubQuiz:
+    """Minimal stand-in for a canvasapi Quiz object."""
+
+    def __init__(self, published=True, due_at=None):
+        """Set published flag and due_at string for the stub."""
+        self.published = published
+        self.due_at = due_at
+
+
+class TestIsQuizOpenForReminder:
+    """Tests for is_quiz_open_for_reminder filter predicate."""
+
+    def _now(self):
+        """Return a frozen UTC reference timestamp for deterministic tests."""
+        from datetime import timezone
+        return datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+
+    def test_published_with_future_due(self):
+        """Published quiz with due_at after now returns True."""
+        from canvigator_utils import is_quiz_open_for_reminder
+        quiz = _StubQuiz(published=True, due_at="2026-04-25T12:00:00Z")
+        assert is_quiz_open_for_reminder(quiz, now=self._now()) is True
+
+    def test_published_with_past_due(self):
+        """Published quiz with due_at before now returns False."""
+        from canvigator_utils import is_quiz_open_for_reminder
+        quiz = _StubQuiz(published=True, due_at="2026-04-23T12:00:00Z")
+        assert is_quiz_open_for_reminder(quiz, now=self._now()) is False
+
+    def test_unpublished_with_future_due(self):
+        """Unpublished quiz returns False even with future due_at."""
+        from canvigator_utils import is_quiz_open_for_reminder
+        quiz = _StubQuiz(published=False, due_at="2026-04-25T12:00:00Z")
+        assert is_quiz_open_for_reminder(quiz, now=self._now()) is False
+
+    def test_due_at_none(self):
+        """Quiz with due_at=None returns False."""
+        from canvigator_utils import is_quiz_open_for_reminder
+        quiz = _StubQuiz(published=True, due_at=None)
+        assert is_quiz_open_for_reminder(quiz, now=self._now()) is False
+
+    def test_due_at_empty_string(self):
+        """Quiz with empty due_at returns False."""
+        from canvigator_utils import is_quiz_open_for_reminder
+        quiz = _StubQuiz(published=True, due_at="")
+        assert is_quiz_open_for_reminder(quiz, now=self._now()) is False
+
+    def test_due_at_malformed(self):
+        """Malformed due_at strings are treated as not-open rather than raising."""
+        from canvigator_utils import is_quiz_open_for_reminder
+        quiz = _StubQuiz(published=True, due_at="not-a-date")
+        assert is_quiz_open_for_reminder(quiz, now=self._now()) is False
+
+    def test_due_at_exactly_now(self):
+        """due_at equal to now is not strictly future, so returns False."""
+        from canvigator_utils import is_quiz_open_for_reminder
+        quiz = _StubQuiz(published=True, due_at="2026-04-24T12:00:00Z")
+        assert is_quiz_open_for_reminder(quiz, now=self._now()) is False
+
+
 # ---------------------------------------------------------------------------
 # canvigator_course anonymization tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The `send-quiz-reminder` interactive picker now lists only quizzes that are **published AND have a `due_at` strictly in the future (UTC)**. Other quiz tasks (`send-follow-up-question`, `assess-replies`, etc.) are unchanged. Fails fast with a clear error if no quiz matches the filter.
- New helper `cu.is_quiz_open_for_reminder` in `canvigator_utils.py` (covered by 7 unit tests in `test_canvigator.py`).
- README: added `delete-old-conversations` to the alphabetical task list and a detailed per-task section, plus the `--months/-m` flag in the usage block and inclusion in the `--dry-run` coverage line.

## Test plan
- [x] `flake8` (both invocations from `CLAUDE.md`) — clean
- [x] `python -m pytest test_canvigator.py -v` — 144/144 pass (7 new)
- [x] Smoke: `send-quiz-reminder` against a course with a mix of past/future-due quizzes — picker now shows only future-due, published quizzes
- [x] Regression smoke: `send-follow-up-question` still shows the full quiz list
- [x] Smoke: in a course with no future-due quizzes, confirm the new clear error message