### PR TITLE
Wire structured rubric, exemplars, and per-criterion voting into assessment

### DIFF
--- a/canvigator_llm.py
+++ b/canvigator_llm.py
@@ -127,6 +127,9 @@ _DRAW_SYSTEM_PROMPT = (
 
 _RUBRIC_COMMON_SCHEMA = (
     '  "canonical_answer": "<concise 1-2 sentence model answer that represents a strong response>",\n'
+    '  "model_answer": "<an 80-120 word fully-developed exemplar of an A-grade student response, '
+    'written in the register a real student would use — informal but substantive — describing '
+    'every concept the response should cover>",\n'
     '  "pass_criteria": ["<2-5 concrete must-haves a passing response must demonstrate>"],\n'
     '  "acceptable_alternatives": ["<equivalent framings, synonyms, or alternative correct approaches that should still count as passing>"],\n'
     '  "common_misconceptions": ["<wrong-but-plausible answers that should NOT count as passing, each with a brief reason>"],\n'
@@ -148,6 +151,9 @@ _RUBRIC_EXPLAIN_SYSTEM_PROMPT = (
     "- Do not repeat the same idea across lists. Pass criteria are what MUST be present; "
     "alternatives are equivalent framings; misconceptions are wrong answers; fatal errors "
     "are auto-fails.\n"
+    "- canonical_answer is a tight 1-2 sentence summary. model_answer is longer (80-120 words), "
+    "phrased the way a strong student would actually speak — informal but substantive — and must "
+    "cover every concept the pass_criteria expect to see.\n"
     "- Focus on conceptual substance, not stylistic polish. The student is speaking, so "
     "informal language is fine — criteria should be about understanding, not phrasing.\n"
     "- All strings must be valid JSON (escape quotes, no trailing commas)."
@@ -169,6 +175,9 @@ _RUBRIC_DRAW_SYSTEM_PROMPT = (
     "- Do not repeat the same idea across lists. Pass criteria cover correctness of structure "
     "or relationships; required_visual_elements are concrete things that should literally "
     "appear in the picture (nodes, edges, labels, arrows, regions).\n"
+    "- canonical_answer is a tight 1-2 sentence summary. model_answer is an 80-120 word prose "
+    "description of what an A-grade student drawing would contain — every shape, label, arrow, "
+    "and structural relationship the picture must show. Describe the picture, do not draw it.\n"
     "- Focus on structural correctness, not artistic quality. Hand-drawn, rough, or "
     "imperfectly-proportioned drawings are fine — criteria should be about the idea being "
     "communicated.\n"
@@ -475,6 +484,7 @@ def _empty_rubric(mode):
     """Return the canonical empty rubric shape for the given mode."""
     base = {
         'canonical_answer': '',
+        'model_answer': '',
         'pass_criteria': [],
         'acceptable_alternatives': [],
         'common_misconceptions': [],
@@ -515,9 +525,10 @@ def _parse_structured_rubric(response, mode):
     if not isinstance(data, dict):
         return out
 
+    string_keys = {'canonical_answer', 'model_answer'}
     for key in out:
         val = data.get(key)
-        if key == 'canonical_answer':
+        if key in string_keys:
             out[key] = str(val).strip() if val else ''
         elif isinstance(val, list):
             out[key] = [str(v).strip() for v in val if v is not None and str(v).strip()]
@@ -570,6 +581,143 @@ def generate_structured_rubric(row, client, model, mode, open_ended_question):
         return _empty_rubric(mode)
 
 
+_EXEMPLARS_EXPLAIN_SYSTEM_PROMPT = (
+    "You are an expert university instructor producing few-shot calibration examples for an "
+    "AI grader. Given a follow-up question and its rubric, write ONE realistic passing student "
+    "response and ONE realistic failing student response, plus a one-sentence note on why each "
+    "sits at the bar.\n\n"
+    "Both responses must read like spoken student responses — informal language, hesitations, "
+    "imperfect phrasing — NOT polished prose. Aim for 50-100 words each.\n\n"
+    "The passing response should be a realistic minimum-bar pass: it covers the core concepts "
+    "but is not perfect (think B/B+ student, not A+). The failing response should sound "
+    "plausible — a student who tried but missed the point, exhibits a misconception, or hit a "
+    "fatal error from the rubric — NOT obvious nonsense or a one-line shrug.\n\n"
+    "Return ONLY a single JSON object with exactly this schema, no prose, no markdown fences:\n"
+    "{\n"
+    '  "exemplar_pass": "<50-100 word realistic spoken passing response>",\n'
+    '  "exemplar_pass_note": "<one-sentence note on why this is at the passing bar>",\n'
+    '  "exemplar_fail": "<50-100 word realistic spoken failing response>",\n'
+    '  "exemplar_fail_note": "<one-sentence note on why this is at the failing bar>"\n'
+    "}"
+)
+
+_EXEMPLARS_DRAW_SYSTEM_PROMPT = (
+    "You are an expert university instructor producing few-shot calibration examples for an "
+    "AI grader. Given a follow-up question and its rubric, write a prose description of ONE "
+    "realistic passing student drawing and ONE realistic failing student drawing, plus a "
+    "one-sentence note on why each sits at the bar.\n\n"
+    "Describe the drawings — do not produce images. Each description should sound like an "
+    "instructor narrating what they see on a piece of paper: shapes, labels, arrows, "
+    "relationships, missing or incorrect parts. 50-100 words each.\n\n"
+    "The passing description should be a realistic minimum-bar pass: structure correct, most "
+    "labels present, but not flawless (think B/B+ student, not A+). The failing description "
+    "should sound plausible — wrong structure, missing critical elements, or shows a "
+    "misconception from the rubric — NOT a blank page.\n\n"
+    "Return ONLY a single JSON object with exactly this schema, no prose, no markdown fences:\n"
+    "{\n"
+    '  "exemplar_pass": "<50-100 word prose description of a passing drawing>",\n'
+    '  "exemplar_pass_note": "<one-sentence note on why this is at the passing bar>",\n'
+    '  "exemplar_fail": "<50-100 word prose description of a failing drawing>",\n'
+    '  "exemplar_fail_note": "<one-sentence note on why this is at the failing bar>"\n'
+    "}"
+)
+
+
+_EMPTY_EXEMPLARS = {
+    'exemplar_pass': '',
+    'exemplar_pass_note': '',
+    'exemplar_fail': '',
+    'exemplar_fail_note': '',
+}
+
+
+def _parse_exemplars(response):
+    """Parse the exemplars JSON response into the canonical 4-key dict."""
+    out = dict(_EMPTY_EXEMPLARS)
+    if not response:
+        return out
+    text = response.strip()
+    text = re.sub(r'^```(?:json)?\s*', '', text, flags=re.IGNORECASE)
+    text = re.sub(r'\s*```\s*$', '', text)
+    brace_start = text.find('{')
+    brace_end = text.rfind('}')
+    if brace_start != -1 and brace_end != -1 and brace_end > brace_start:
+        text = text[brace_start:brace_end + 1]
+    try:
+        data = json.loads(text)
+    except (ValueError, TypeError):
+        logger.warning(f"Exemplars JSON parse failed; raw response starts with: {response[:200]!r}")
+        return out
+    if not isinstance(data, dict):
+        return out
+    for key in out:
+        v = data.get(key)
+        out[key] = str(v).strip() if v else ''
+    return out
+
+
+def _build_exemplars_prompt(keywords, original_question_text, answers_json, mode, open_ended_question, rubric):
+    """Build the user-side prompt for exemplar generation."""
+    clean_text = _strip_html(original_question_text)
+    labels = _answer_labels(answers_json)
+    parts = []
+    if keywords:
+        parts.append(f"Topic keywords: {keywords}")
+    if clean_text:
+        parts.append(f"Original quiz question: {clean_text}")
+    if labels:
+        joined = " | ".join(labels[:6])
+        parts.append(f"Answer choices from the original: {joined}")
+    parts.append(f"Question type: {'draw (hand-drawn diagram)' if mode == 'draw' else 'explain (verbal explanation)'}")
+    parts.append(f"Open-ended question the student will answer: {open_ended_question}")
+
+    rubric_lines = []
+    if rubric.get('canonical_answer'):
+        rubric_lines.append(f"Canonical answer: {rubric['canonical_answer']}")
+    if rubric.get('pass_criteria'):
+        rubric_lines.append("Pass criteria: " + "; ".join(rubric['pass_criteria']))
+    if rubric.get('common_misconceptions'):
+        rubric_lines.append("Common misconceptions: " + "; ".join(rubric['common_misconceptions']))
+    if rubric.get('fatal_errors'):
+        rubric_lines.append("Fatal errors: " + "; ".join(rubric['fatal_errors']))
+    if mode == 'draw' and rubric.get('required_visual_elements'):
+        rubric_lines.append("Required visual elements: " + "; ".join(rubric['required_visual_elements']))
+    if rubric_lines:
+        parts.append("Rubric:")
+        parts.extend(rubric_lines)
+    parts.append("Exemplars JSON:")
+    return "\n".join(parts)
+
+
+def generate_exemplars(row, client, model, mode, open_ended_question, rubric):
+    """Call the LLM to produce one passing + one failing exemplar response for the question."""
+    if not open_ended_question:
+        return dict(_EMPTY_EXEMPLARS)
+    prompt = _build_exemplars_prompt(
+        row.get("keywords"),
+        row.get("question_text"),
+        row.get("answers"),
+        mode,
+        open_ended_question,
+        rubric or _empty_rubric(mode),
+    )
+    system_prompt = _EXEMPLARS_DRAW_SYSTEM_PROMPT if mode == 'draw' else _EXEMPLARS_EXPLAIN_SYSTEM_PROMPT
+    try:
+        resp = _chat_with_retry(
+            client,
+            model=model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ],
+            options={"temperature": 0.5},
+        )
+        return _parse_exemplars(resp["message"]["content"])
+    except Exception as e:
+        logger.warning(f"LLM exemplar generation failed for question {row.get('question_id')}: {e}")
+        return dict(_EMPTY_EXEMPLARS)
+
+
 _TRANSCRIBE_SYSTEM_PROMPT = (
     "You are a transcription assistant. Listen to the audio and produce an accurate, "
     "verbatim transcription of everything the speaker says. Output ONLY the transcription "
@@ -578,68 +726,280 @@ _TRANSCRIBE_SYSTEM_PROMPT = (
 
 _ASSESS_EXPLAIN_SYSTEM_PROMPT = (
     "You are a university instructor assessing a student's verbal explanation of a concept. "
-    "Given the original quiz question, the topic keywords, and the student's spoken response "
-    "(provided as a transcript), determine whether the student demonstrates a reasonable "
-    "understanding of the core concept.\n\n"
-    "If an \"Assessment guide\" is provided in the user message, treat it as the primary "
-    "rubric for deciding pass vs. fail — it was written by the instructor who knows what a "
-    "correct response looks like.\n\n"
-    "A \"pass\" means the student demonstrates a reasonable understanding of the core concept, "
-    "even if their explanation is imprecise, incomplete, or uses informal language. "
-    "A \"fail\" means the student shows a fundamental misunderstanding, did not address the "
-    "question, or gave a response with no substantive content.\n\n"
-    "Respond in EXACTLY this format (two lines):\n"
-    "Result: pass\n"
-    "Feedback: Your 2-3 sentence feedback here.\n\n"
-    "Or:\n"
-    "Result: fail\n"
-    "Feedback: Your 2-3 sentence feedback here."
+    "You will be given the original quiz question, topic keywords, the follow-up question asked, "
+    "a structured rubric, an instructor-written assessment guide, optionally a model answer and "
+    "calibration exemplars and previously-graded examples, and the student's spoken response "
+    "(as a transcript).\n\n"
+    "Walk the rubric one item at a time. For EACH pass criterion answer met / partial / missing. "
+    "For EACH fatal error answer absent / present. Be charitable: informal phrasing, hesitation, "
+    "and incomplete-but-substantive coverage should still earn met or partial. A student who "
+    "repeats the question, says \"I don't know\", or shows a fundamental misunderstanding fails.\n\n"
+    "Then write 2-3 sentences of feedback for the student that references the criteria they met "
+    "and missed.\n\n"
+    "Return ONLY a single JSON object with this exact schema (no prose, no markdown fences):\n\n"
+    "{\n"
+    '  "pass_criteria_evaluations": [\n'
+    '    {"criterion": "<the criterion text, copied verbatim from the rubric>", "status": "met"|"partial"|"missing"}\n'
+    "  ],\n"
+    '  "fatal_errors_evaluations": [\n'
+    '    {"error": "<the error text, copied verbatim from the rubric>", "status": "absent"|"present"}\n'
+    "  ],\n"
+    '  "feedback": "<2-3 sentences of feedback for the student>"\n'
+    "}\n\n"
+    "Include exactly one entry per rubric item — no more, no less. If the rubric supplies an "
+    "empty list, return an empty list. Do not invent criteria or errors that were not in the rubric."
 )
 
 _ASSESS_DRAW_SYSTEM_PROMPT = (
     "You are a university instructor assessing a student's hand-drawn diagram or figure. "
-    "Given the original quiz question, the topic keywords, and the student's drawing "
-    "(provided as an image), determine whether the drawing demonstrates a reasonable "
-    "understanding of the key concepts and relationships.\n\n"
-    "If an \"Assessment guide\" is provided in the user message, treat it as the primary "
-    "rubric for deciding pass vs. fail — it was written by the instructor who knows what a "
-    "correct drawing looks like.\n\n"
-    "A \"pass\" means the drawing shows the essential structure or relationships, even if "
-    "it is rough, has minor inaccuracies, or is missing non-critical labels. "
-    "A \"fail\" means the drawing is fundamentally incorrect, shows the wrong structure, "
-    "is missing critical elements, or does not address the question.\n\n"
-    "Respond in EXACTLY this format (two lines):\n"
-    "Result: pass\n"
-    "Feedback: Your 2-3 sentence feedback here.\n\n"
-    "Or:\n"
-    "Result: fail\n"
-    "Feedback: Your 2-3 sentence feedback here."
+    "You will be given the original quiz question, topic keywords, the follow-up question asked, "
+    "a structured rubric, an instructor-written assessment guide, optionally a model answer and "
+    "calibration exemplars, and the student's drawing (as an image).\n\n"
+    "Walk the rubric one item at a time. For EACH pass criterion answer met / partial / missing. "
+    "For EACH fatal error answer absent / present. For EACH required visual element answer "
+    "yes / no / unclear based on what literally appears in the drawing. Be charitable about "
+    "neatness — rough hand-drawn diagrams with the right structure should pass.\n\n"
+    "Then write 2-3 sentences of feedback that references which elements are present and which "
+    "are missing.\n\n"
+    "Return ONLY a single JSON object with this exact schema (no prose, no markdown fences):\n\n"
+    "{\n"
+    '  "pass_criteria_evaluations": [\n'
+    '    {"criterion": "<the criterion text, copied verbatim from the rubric>", "status": "met"|"partial"|"missing"}\n'
+    "  ],\n"
+    '  "fatal_errors_evaluations": [\n'
+    '    {"error": "<the error text, copied verbatim from the rubric>", "status": "absent"|"present"}\n'
+    "  ],\n"
+    '  "visual_elements_evaluations": [\n'
+    '    {"element": "<the element text, copied verbatim from the rubric>", "status": "yes"|"no"|"unclear"}\n'
+    "  ],\n"
+    '  "feedback": "<2-3 sentences of feedback for the student>"\n'
+    "}\n\n"
+    "Include exactly one entry per rubric item — no more, no less. Do not invent items that were "
+    "not in the rubric."
 )
 
 
-def _parse_assessment(response):
-    r"""Parse a 'Result: pass/fail\nFeedback: ...' response into (result, feedback)."""
+_VALID_PASS_STATUSES = {'met', 'partial', 'missing'}
+_VALID_FATAL_STATUSES = {'absent', 'present'}
+_VALID_VISUAL_STATUSES = {'yes', 'no', 'unclear'}
+
+
+def _parse_per_criterion_response(response, mode):
+    """Parse Gemma's JSON response into a per-criterion evaluation dict.
+
+    Returns a dict with keys: pass_criteria_evaluations, fatal_errors_evaluations,
+    visual_elements_evaluations (draw mode only), feedback. Statuses outside the
+    permitted vocabulary degrade to the worst-case (missing / present / no) so a
+    bogus status never silently flips a fail to a pass.
+    """
+    out = {
+        'pass_criteria_evaluations': [],
+        'fatal_errors_evaluations': [],
+        'feedback': '',
+    }
+    if mode == 'draw':
+        out['visual_elements_evaluations'] = []
     if not response:
-        return 'fail', 'No response from model.'
+        return out
 
-    result = 'fail'
-    feedback = ''
-    for line in response.strip().splitlines():
-        line_stripped = line.strip()
-        if line_stripped.lower().startswith('result:'):
-            token = line_stripped[len('result:'):].strip().lower().strip('.,')
-            result = 'pass' if token == 'pass' else 'fail'
-        elif line_stripped.lower().startswith('feedback:'):
-            feedback = line_stripped[len('feedback:'):].strip()
+    text = response.strip()
+    text = re.sub(r'^```(?:json)?\s*', '', text, flags=re.IGNORECASE)
+    text = re.sub(r'\s*```\s*$', '', text)
+    brace_start = text.find('{')
+    brace_end = text.rfind('}')
+    if brace_start != -1 and brace_end != -1 and brace_end > brace_start:
+        text = text[brace_start:brace_end + 1]
 
-    if not feedback:
-        # Fallback: treat the whole response as feedback
-        feedback = response.strip()
+    try:
+        data = json.loads(text)
+    except (ValueError, TypeError):
+        logger.warning(f"Per-criterion JSON parse failed; raw response starts with: {response[:200]!r}")
+        return out
+    if not isinstance(data, dict):
+        return out
 
-    return result, feedback
+    def _normalize(items, item_key, status_key, valid, worst):
+        result = []
+        if not isinstance(items, list):
+            return result
+        for entry in items:
+            if not isinstance(entry, dict):
+                continue
+            text = str(entry.get(item_key, '')).strip()
+            status = str(entry.get('status', '')).strip().lower()
+            if status not in valid:
+                status = worst
+            if text:
+                result.append({item_key: text, 'status': status})
+        return result
+
+    out['pass_criteria_evaluations'] = _normalize(
+        data.get('pass_criteria_evaluations'), 'criterion', 'status',
+        _VALID_PASS_STATUSES, 'missing',
+    )
+    out['fatal_errors_evaluations'] = _normalize(
+        data.get('fatal_errors_evaluations'), 'error', 'status',
+        _VALID_FATAL_STATUSES, 'present',
+    )
+    if mode == 'draw':
+        out['visual_elements_evaluations'] = _normalize(
+            data.get('visual_elements_evaluations'), 'element', 'status',
+            _VALID_VISUAL_STATUSES, 'no',
+        )
+    fb = data.get('feedback')
+    out['feedback'] = str(fb).strip() if fb else ''
+    return out
 
 
-def _build_assessment_prompt(keywords, open_ended_question, original_question_text, transcript=None, assessment_guide=None):
+_AGGREGATION_THRESHOLD = 0.5
+
+
+def _aggregate_pass_fail(per_criterion, mode):
+    """Compute deterministic pass/fail from a parsed per-criterion evaluation dict.
+
+    Pass requires:
+    - pass-criteria score (met=1, partial=0.5, missing=0) / count >= 0.5,
+      defaulting to pass when there are zero criteria.
+    - No fatal error marked present.
+    - For draw mode: visual-elements score (yes=1, unclear=0.5, no=0) / count >= 0.5,
+      defaulting to pass when there are zero visual elements.
+    """
+    pass_items = per_criterion.get('pass_criteria_evaluations', [])
+    if pass_items:
+        pass_score = sum(
+            1.0 if e['status'] == 'met' else (0.5 if e['status'] == 'partial' else 0.0)
+            for e in pass_items
+        ) / len(pass_items)
+    else:
+        pass_score = 1.0
+
+    fatal_items = per_criterion.get('fatal_errors_evaluations', [])
+    fatal_present = any(e['status'] == 'present' for e in fatal_items)
+
+    visual_score = 1.0
+    if mode == 'draw':
+        visual_items = per_criterion.get('visual_elements_evaluations', [])
+        if visual_items:
+            visual_score = sum(
+                1.0 if e['status'] == 'yes' else (0.5 if e['status'] == 'unclear' else 0.0)
+                for e in visual_items
+            ) / len(visual_items)
+
+    passed = (
+        pass_score >= _AGGREGATION_THRESHOLD and
+        not fatal_present and
+        visual_score >= _AGGREGATION_THRESHOLD
+    )
+    return 'pass' if passed else 'fail'
+
+
+def _render_rubric_block(rubric, mode):
+    """Render a structured rubric dict as a prompt-ready bullet block.
+
+    Returns an empty string when the rubric is empty so callers can drop the
+    section cleanly.
+    """
+    if not rubric:
+        return ''
+    blocks = []
+    if rubric.get('canonical_answer'):
+        blocks.append(f"Canonical answer (1-2 sentence summary): {rubric['canonical_answer']}")
+    if rubric.get('model_answer'):
+        blocks.append(
+            "Model answer (an A-grade response in a real student's voice — use this as a "
+            f"depth/coverage reference, the student does NOT need to phrase things this way):\n{rubric['model_answer']}"
+        )
+    if rubric.get('pass_criteria'):
+        bullets = "\n".join(f"- {c}" for c in rubric['pass_criteria'])
+        blocks.append(
+            "Pass criteria (the student's response MUST demonstrate these — evaluate each one):\n"
+            f"{bullets}"
+        )
+    if rubric.get('acceptable_alternatives'):
+        bullets = "\n".join(f"- {c}" for c in rubric['acceptable_alternatives'])
+        blocks.append(
+            "Acceptable alternative framings (count these as equivalent to the criteria):\n"
+            f"{bullets}"
+        )
+    if rubric.get('common_misconceptions'):
+        bullets = "\n".join(f"- {c}" for c in rubric['common_misconceptions'])
+        blocks.append(
+            "Common misconceptions (do NOT count these as passing):\n"
+            f"{bullets}"
+        )
+    if rubric.get('fatal_errors'):
+        bullets = "\n".join(f"- {c}" for c in rubric['fatal_errors'])
+        blocks.append(
+            "Fatal errors (any of these forces a fail — evaluate each one):\n"
+            f"{bullets}"
+        )
+    if mode == 'draw' and rubric.get('required_visual_elements'):
+        bullets = "\n".join(f"- {c}" for c in rubric['required_visual_elements'])
+        blocks.append(
+            "Required visual elements — walk the drawing one element at a time, marking yes / "
+            "no / unclear based on what is literally drawn:\n"
+            f"{bullets}"
+        )
+    return "\n\n".join(blocks)
+
+
+def _render_exemplars_block(exemplars):
+    """Render Gemini-authored pass/fail exemplars as a prompt-ready section."""
+    if not exemplars:
+        return ''
+    p_resp = exemplars.get('exemplar_pass') or ''
+    p_note = exemplars.get('exemplar_pass_note') or ''
+    f_resp = exemplars.get('exemplar_fail') or ''
+    f_note = exemplars.get('exemplar_fail_note') or ''
+    if not (p_resp or f_resp):
+        return ''
+    parts = ["Calibration exemplars (use these to anchor the bar, not as ground truth):"]
+    if p_resp:
+        parts.append(f'Passing example: "{p_resp}"')
+        if p_note:
+            parts.append(f"  (Note: {p_note})")
+    if f_resp:
+        parts.append(f'Failing example: "{f_resp}"')
+        if f_note:
+            parts.append(f"  (Note: {f_note})")
+    return "\n".join(parts)
+
+
+def _render_locked_examples_block(locked_examples):
+    """Render previously instructor-approved assessments as in-context few-shot examples.
+
+    Each entry should be a dict with keys: response, result, feedback. Caller is
+    responsible for sampling — this function just renders.
+    """
+    if not locked_examples:
+        return ''
+    parts = ["Previously-graded examples for this question (instructor-approved verdicts):"]
+    for i, ex in enumerate(locked_examples, start=1):
+        resp = (ex.get('response') or '').strip()
+        result = (ex.get('result') or '').strip()
+        feedback = (ex.get('feedback') or '').strip()
+        if not resp or not result:
+            continue
+        parts.append(f'Example {i} student response: "{resp}"')
+        parts.append(f"Example {i} verdict: {result}")
+        if feedback:
+            parts.append(f"Example {i} instructor feedback: {feedback}")
+    if len(parts) == 1:
+        return ''
+    return "\n".join(parts)
+
+
+def _build_assessment_prompt(
+    keywords,
+    open_ended_question,
+    original_question_text,
+    transcript=None,
+    assessment_guide=None,
+    rubric=None,
+    exemplars=None,
+    locked_examples=None,
+    mode='explain',
+):
     """Build the user-side prompt for assessing a student response."""
     parts = []
     if keywords:
@@ -649,10 +1009,23 @@ def _build_assessment_prompt(keywords, open_ended_question, original_question_te
     if open_ended_question:
         parts.append(f"Follow-up question asked: {open_ended_question}")
     if assessment_guide:
-        parts.append(f"Assessment guide (use this as your primary rubric): {assessment_guide}")
+        parts.append(f"Assessment guide (instructor framing): {assessment_guide}")
+
+    rubric_block = _render_rubric_block(rubric, mode)
+    if rubric_block:
+        parts.append(rubric_block)
+
+    exemplars_block = _render_exemplars_block(exemplars)
+    if exemplars_block:
+        parts.append(exemplars_block)
+
+    locked_block = _render_locked_examples_block(locked_examples)
+    if locked_block:
+        parts.append(locked_block)
+
     if transcript:
         parts.append(f"Student's response (transcript): {transcript}")
-    return "\n".join(parts)
+    return "\n\n".join(parts)
 
 
 def transcribe_audio(audio_path, client, model):
@@ -673,12 +1046,8 @@ def transcribe_audio(audio_path, client, model):
         return ""
 
 
-def assess_explain(transcript, keywords, open_ended_question, original_question_text, client, model, assessment_guide=None):
-    """Assess a student's verbal explanation using the transcript."""
-    prompt = _build_assessment_prompt(
-        keywords, open_ended_question, original_question_text,
-        transcript=transcript, assessment_guide=assessment_guide,
-    )
+def _assess_explain_once(prompt, client, model):
+    """Single-pass explain assessment. Returns (result, feedback, evaluations_dict)."""
     try:
         resp = _chat_with_retry(
             client,
@@ -689,18 +1058,15 @@ def assess_explain(transcript, keywords, open_ended_question, original_question_
             ],
             options={"temperature": 0.3},
         )
-        return _parse_assessment(resp["message"]["content"])
+        evals = _parse_per_criterion_response(resp["message"]["content"], 'explain')
     except Exception as e:
         logger.warning(f"Explain assessment failed: {e}")
-        return 'fail', f'Assessment error: {e}'
+        return 'fail', f'Assessment error: {e}', _parse_per_criterion_response('', 'explain')
+    return _aggregate_pass_fail(evals, 'explain'), evals.get('feedback', ''), evals
 
 
-def assess_draw(image_path, keywords, open_ended_question, original_question_text, client, model, assessment_guide=None):
-    """Assess a student's drawing by sending the image to a multimodal model."""
-    prompt = _build_assessment_prompt(
-        keywords, open_ended_question, original_question_text,
-        assessment_guide=assessment_guide,
-    )
+def _assess_draw_once(prompt, image_path, client, model):
+    """Single-pass draw assessment. Returns (result, feedback, evaluations_dict)."""
     try:
         resp = _chat_with_retry(
             client,
@@ -712,19 +1078,101 @@ def assess_draw(image_path, keywords, open_ended_question, original_question_tex
             ],
             options={"temperature": 0.3},
         )
-        return _parse_assessment(resp["message"]["content"])
+        evals = _parse_per_criterion_response(resp["message"]["content"], 'draw')
     except Exception as e:
         logger.warning(f"Draw assessment failed for {image_path}: {e}")
-        return 'fail', f'Assessment error: {e}'
+        return 'fail', f'Assessment error: {e}', _parse_per_criterion_response('', 'draw')
+    return _aggregate_pass_fail(evals, 'draw'), evals.get('feedback', ''), evals
 
 
-def assess_replies(replies, question_info_row, model=None, audio_model=None):
+_SELF_CONSISTENCY_N = 3
+
+
+def _vote_assessments(runs):
+    """Majority-vote a list of (result, feedback, evals) tuples.
+
+    Returns (result, confidence, feedback, evals) where confidence is "high"
+    when all runs agree and "borderline" otherwise. The feedback and evals are
+    drawn from the first run that matches the majority verdict so the per-criterion
+    audit trail aligns with the reported result.
+    """
+    if not runs:
+        return 'fail', 'borderline', 'No assessment runs completed.', {}
+    n_pass = sum(1 for r, _, _ in runs if r == 'pass')
+    n_fail = len(runs) - n_pass
+    majority = 'pass' if n_pass >= n_fail else 'fail'
+    confidence = 'high' if (n_pass == 0 or n_fail == 0) else 'borderline'
+    for r, fb, ev in runs:
+        if r == majority:
+            return majority, confidence, fb, ev
+    r, fb, ev = runs[0]
+    return r, confidence, fb, ev
+
+
+def assess_explain(transcript, keywords, open_ended_question, original_question_text, client, model,
+                   assessment_guide=None, rubric=None, exemplars=None, locked_examples=None,
+                   n_consistency=_SELF_CONSISTENCY_N):
+    """Assess a verbal explanation, running N self-consistency passes.
+
+    Returns (result, confidence, feedback, evaluations).
+    """
+    prompt = _build_assessment_prompt(
+        keywords, open_ended_question, original_question_text,
+        transcript=transcript, assessment_guide=assessment_guide,
+        rubric=rubric, exemplars=exemplars, locked_examples=locked_examples,
+        mode='explain',
+    )
+    runs = [_assess_explain_once(prompt, client, model) for _ in range(n_consistency)]
+    return _vote_assessments(runs)
+
+
+def assess_draw(image_path, keywords, open_ended_question, original_question_text, client, model,
+                assessment_guide=None, rubric=None, exemplars=None, locked_examples=None,
+                n_consistency=_SELF_CONSISTENCY_N):
+    """Assess a hand-drawn diagram, running N self-consistency passes.
+
+    Returns (result, confidence, feedback, evaluations).
+    """
+    prompt = _build_assessment_prompt(
+        keywords, open_ended_question, original_question_text,
+        assessment_guide=assessment_guide, rubric=rubric, exemplars=exemplars,
+        locked_examples=locked_examples, mode='draw',
+    )
+    runs = [_assess_draw_once(prompt, image_path, client, model) for _ in range(n_consistency)]
+    return _vote_assessments(runs)
+
+
+def _parse_rubric_from_row(question_info_row):
+    """Extract rubric and exemplars from an open-ended question row dict."""
+    mode = (question_info_row.get('question_mode') or 'explain').strip().lower()
+    rubric_raw = question_info_row.get('rubric_json') or ''
+    if isinstance(rubric_raw, str) and rubric_raw.strip():
+        rubric = _parse_structured_rubric(rubric_raw, 'draw' if mode == 'draw' else 'explain')
+    else:
+        rubric = _empty_rubric('draw' if mode == 'draw' else 'explain')
+    exemplars = {
+        'exemplar_pass': str(question_info_row.get('exemplar_pass') or '').strip(),
+        'exemplar_pass_note': str(question_info_row.get('exemplar_pass_note') or '').strip(),
+        'exemplar_fail': str(question_info_row.get('exemplar_fail') or '').strip(),
+        'exemplar_fail_note': str(question_info_row.get('exemplar_fail_note') or '').strip(),
+    }
+    return rubric, exemplars, mode
+
+
+def assess_replies(replies, question_info_row, model=None, audio_model=None,
+                   locked_examples=None, n_consistency=_SELF_CONSISTENCY_N):
     """Assess a list of student reply dicts, returning a list of assessment result dicts.
 
     Each reply dict should have keys: student_id, student_name, question_id,
     question_mode, reply_text, attachment_path, audio_path.
 
-    question_info_row should have: keywords, open_ended_question, original_question_text.
+    question_info_row should have: keywords, open_ended_question,
+    original_question_text, assessment_guide, rubric_json, and the four
+    exemplar_* columns.
+
+    locked_examples (optional): list of dicts {response, result, feedback}
+    drawn from previously instructor-approved assessments for the same question.
+    Used as in-context few-shot calibration.
     """
     try:
         import ollama  # noqa: F401
@@ -750,9 +1198,10 @@ def assess_replies(replies, question_info_row, model=None, audio_model=None):
     oe_question = question_info_row.get('open_ended_question', '')
     orig_text = question_info_row.get('original_question_text', '')
     assessment_guide = question_info_row.get('assessment_guide', '') or ''
+    rubric, exemplars, _row_mode = _parse_rubric_from_row(question_info_row)
 
     total = len(replies)
-    print(f"Assessing {total} student replies with model '{model}'...")
+    print(f"Assessing {total} student replies with model '{model}' (n={n_consistency} self-consistency)...")
     results = []
     for i, reply in enumerate(replies, start=1):
         student_name = reply.get('student_name', '?')
@@ -760,6 +1209,7 @@ def assess_replies(replies, question_info_row, model=None, audio_model=None):
         print(f"  [{i}/{total}] {student_name} ({mode})...", end="", flush=True)
 
         transcript = ''
+        evaluations = {}
         if mode == 'explain':
             audio_path = reply.get('audio_path', '')
             if audio_path:
@@ -776,15 +1226,18 @@ def assess_replies(replies, question_info_row, model=None, audio_model=None):
                     'question_id': reply['question_id'],
                     'question_mode': mode,
                     'result': 'fail',
+                    'confidence': 'high',
                     'feedback': 'No response content to assess (no audio and no text).',
                     'transcript': '',
+                    'criteria_evaluations': '',
                     'assessed_at': '',
                 })
                 continue
-            print(" assessing...", end="", flush=True)
-            result, feedback = assess_explain(
+            print(f" assessing (x{n_consistency})...", end="", flush=True)
+            result, confidence, feedback, evaluations = assess_explain(
                 transcript, keywords, oe_question, orig_text, client, model,
-                assessment_guide=assessment_guide,
+                assessment_guide=assessment_guide, rubric=rubric, exemplars=exemplars,
+                locked_examples=locked_examples, n_consistency=n_consistency,
             )
         else:
             # Draw mode
@@ -797,21 +1250,24 @@ def assess_replies(replies, question_info_row, model=None, audio_model=None):
                     'question_id': reply['question_id'],
                     'question_mode': mode,
                     'result': 'fail',
+                    'confidence': 'high',
                     'feedback': 'No image attachment to assess.',
                     'transcript': '',
+                    'criteria_evaluations': '',
                     'assessed_at': '',
                 })
                 continue
-            transcript = ''
-            print(" assessing image...", end="", flush=True)
-            result, feedback = assess_draw(
+            print(f" assessing image (x{n_consistency})...", end="", flush=True)
+            # locked_examples carry transcripts, which don't apply to drawings — drop them.
+            result, confidence, feedback, evaluations = assess_draw(
                 image_path, keywords, oe_question, orig_text, client, model,
-                assessment_guide=assessment_guide,
+                assessment_guide=assessment_guide, rubric=rubric, exemplars=exemplars,
+                locked_examples=None, n_consistency=n_consistency,
             )
 
         from datetime import datetime, timezone
         assessed_at = datetime.now(timezone.utc).isoformat()
-        print(f" {result}")
+        print(f" {result} ({confidence})")
 
         results.append({
             'student_id': reply['student_id'],
@@ -819,8 +1275,10 @@ def assess_replies(replies, question_info_row, model=None, audio_model=None):
             'question_id': reply['question_id'],
             'question_mode': mode,
             'result': result,
+            'confidence': confidence,
             'feedback': feedback,
             'transcript': transcript,
+            'criteria_evaluations': json.dumps(evaluations, ensure_ascii=False) if evaluations else '',
             'assessed_at': assessed_at,
         })
 
@@ -874,12 +1332,13 @@ def generate_open_ended_questions(rows, model=None, n=3, progress=None):
         candidates = generate_open_ended_candidates(row, client, model, mode, n=n)
         non_empty = len([c for c in candidates if c])
         if spin_fn:
-            spin_fn(frame, f"[{i}/{total}] {label} — writing {non_empty} guide(s) + rubric(s)")
+            spin_fn(frame, f"[{i}/{total}] {label} — writing {non_empty} guide(s) + rubric(s) + exemplars")
             frame += 1
         else:
-            print(f" writing {non_empty} guide(s) + rubric(s)...", end="", flush=True)
+            print(f" writing {non_empty} guide(s) + rubric(s) + exemplars...", end="", flush=True)
         guides = [generate_assessment_guide(row, client, model, mode, cand) for cand in candidates]
         rubrics = [generate_structured_rubric(row, client, model, mode, cand) for cand in candidates]
+        exemplars = [generate_exemplars(row, client, model, mode, cand, rub) for cand, rub in zip(candidates, rubrics)]
         if not spin_fn:
             print(" done")
 
@@ -890,8 +1349,9 @@ def generate_open_ended_questions(rows, model=None, n=3, progress=None):
         padded_candidates = (candidates + [''] * n)[:n]
         padded_guides = (guides + [''] * n)[:n]
         padded_rubrics = (rubrics + [_empty_rubric(mode)] * n)[:n]
+        padded_exemplars = (exemplars + [dict(_EMPTY_EXEMPLARS)] * n)[:n]
         original_text = _strip_html(row.get('question_text'))
-        for cand, guide, rubric in zip(padded_candidates, padded_guides, padded_rubrics):
+        for cand, guide, rubric, ex in zip(padded_candidates, padded_guides, padded_rubrics, padded_exemplars):
             results.append({
                 'selected_question': 0,
                 'question_id': row.get('question_id'),
@@ -902,6 +1362,10 @@ def generate_open_ended_questions(rows, model=None, n=3, progress=None):
                 'open_ended_question': cand,
                 'assessment_guide': guide,
                 'rubric_json': json.dumps(rubric, ensure_ascii=False),
+                'exemplar_pass': ex.get('exemplar_pass', ''),
+                'exemplar_pass_note': ex.get('exemplar_pass_note', ''),
+                'exemplar_fail': ex.get('exemplar_fail', ''),
+                'exemplar_fail_note': ex.get('exemplar_fail_note', ''),
                 'original_question_text': original_text,
             })
     if spin_done_fn:

--- a/canvigator_quiz.py
+++ b/canvigator_quiz.py
@@ -295,7 +295,8 @@ def generateOpenEndedQuestions(tagged_csv_path):
     out_df = pd.DataFrame(results, columns=[
         'selected_question', 'question_id', 'position', 'question_name',
         'keywords', 'question_mode', 'open_ended_question', 'assessment_guide',
-        'rubric_json', 'original_question_text',
+        'rubric_json', 'exemplar_pass', 'exemplar_pass_note',
+        'exemplar_fail', 'exemplar_fail_note', 'original_question_text',
     ])
     csv_name = tagged_csv_path.parent / f"{prefix}open_ended_{today_str()}.csv"
     out_df.to_csv(csv_name, index=False)
@@ -1259,8 +1260,12 @@ class CanvigatorQuiz:
                 p = str(p)
                 r[key] = p if os.path.isabs(p) else str(data_root / p)
 
+        locked_examples = self._collectLockedExamples(existing_df, question_id)
+        if locked_examples:
+            print(f"  Using {len(locked_examples)} instructor-approved example(s) for calibration.")
+
         import canvigator_llm
-        results = canvigator_llm.assess_replies(to_assess, oe_row)
+        results = canvigator_llm.assess_replies(to_assess, oe_row, locked_examples=locked_examples)
 
         # Carry conversation_id from the reply (or fall back to manifest lookup).
         convo_lookup = self._buildConversationLookup()
@@ -1301,8 +1306,8 @@ class CanvigatorQuiz:
 
     ASSESSMENTS_COLUMNS = [
         'student_id', 'student_name', 'question_id', 'question_mode',
-        'conversation_id', 'result', 'feedback', 'transcript',
-        'assessed_at', 'sent_assessment', 'sent_at',
+        'conversation_id', 'result', 'confidence', 'feedback', 'transcript',
+        'criteria_evaluations', 'assessed_at', 'sent_assessment', 'sent_at',
     ]
 
     def _assessmentsPath(self):
@@ -1342,6 +1347,43 @@ class CanvigatorQuiz:
             if pd.notna(sid) and pd.notna(qid):
                 out[(int(sid), int(qid))] = row.to_dict()
         return out
+
+    LOCKED_EXAMPLES_PER_BUCKET = 3
+
+    def _collectLockedExamples(self, df, question_id):
+        """Sample locked (sent_assessment=1) explain-mode prior assessments for question_id.
+
+        Returns a list of {response, result, feedback} dicts — up to
+        LOCKED_EXAMPLES_PER_BUCKET passes and the same number of fails. Draw mode
+        is skipped because its `transcript` field is empty (the response is the
+        image, which we can't put in a text prompt).
+        """
+        if df is None or df.empty:
+            return []
+        qid_match = df['question_id'].apply(lambda v: pd.notna(v) and int(v) == int(question_id))
+        sent_match = df['sent_assessment'].fillna(0).astype(int) == 1
+        mode_match = df['question_mode'].fillna('explain').astype(str).str.lower() == 'explain'
+        sub = df[qid_match & sent_match & mode_match]
+        if sub.empty:
+            return []
+
+        examples = []
+        for label in ('pass', 'fail'):
+            bucket = sub[sub['result'].astype(str).str.lower() == label]
+            if bucket.empty:
+                continue
+            bucket = bucket.tail(self.LOCKED_EXAMPLES_PER_BUCKET)
+            for _, row in bucket.iterrows():
+                transcript = str(row.get('transcript') or '').strip()
+                feedback = str(row.get('feedback') or '').strip()
+                if not transcript:
+                    continue
+                examples.append({
+                    'response': transcript,
+                    'result': label,
+                    'feedback': feedback,
+                })
+        return examples
 
     def _buildConversationLookup(self):
         """Scan all *_followup_sent_*.csv manifests for (student_id, question_id) -> conversation_id."""

--- a/test_canvigator.py
+++ b/test_canvigator.py
@@ -1133,11 +1133,11 @@ class TestExtractStudentReplies:
 class TestAssessmentsMerge:
     """Tests for CanvigatorQuiz._mergeAssessments and _indexAssessments."""
 
-    COLS = [
-        'student_id', 'student_name', 'question_id', 'question_mode',
-        'conversation_id', 'result', 'feedback', 'transcript',
-        'assessed_at', 'sent_assessment', 'sent_at',
-    ]
+    @property
+    def COLS(self):
+        """Pull the canonical column list from the production class so tests track it."""
+        from canvigator_quiz import CanvigatorQuiz
+        return list(CanvigatorQuiz.ASSESSMENTS_COLUMNS)
 
     def _stub(self):
         """Return a CanvigatorQuiz stand-in carrying just ASSESSMENTS_COLUMNS."""
@@ -1155,7 +1155,8 @@ class TestAssessmentsMerge:
         base = {
             'student_id': sid, 'student_name': f's{sid}', 'question_id': qid,
             'question_mode': 'explain', 'conversation_id': 100 + sid,
-            'result': 'pass', 'feedback': 'fb', 'transcript': '',
+            'result': 'pass', 'confidence': 'high', 'feedback': 'fb',
+            'transcript': '', 'criteria_evaluations': '',
             'assessed_at': '2026-04-22T00:00:00Z', 'sent_assessment': 0, 'sent_at': '',
         }
         base.update(overrides)
@@ -1404,55 +1405,6 @@ class TestIntegerAlignedBins:
 # canvigator_llm: assessment helper tests
 # ---------------------------------------------------------------------------
 
-class TestParseAssessment:
-    """Tests for canvigator_llm._parse_assessment."""
-
-    def test_parses_pass(self):
-        """Correctly parses a pass result with feedback."""
-        from canvigator_llm import _parse_assessment
-        result, feedback = _parse_assessment("Result: pass\nFeedback: Good explanation of the concept.")
-        assert result == 'pass'
-        assert feedback == 'Good explanation of the concept.'
-
-    def test_parses_fail(self):
-        """Correctly parses a fail result with feedback."""
-        from canvigator_llm import _parse_assessment
-        result, feedback = _parse_assessment("Result: fail\nFeedback: The student did not address the question.")
-        assert result == 'fail'
-        assert feedback == 'The student did not address the question.'
-
-    def test_defaults_to_fail_on_empty(self):
-        """Returns fail with default feedback on empty input."""
-        from canvigator_llm import _parse_assessment
-        result, feedback = _parse_assessment("")
-        assert result == 'fail'
-
-    def test_defaults_to_fail_on_none(self):
-        """Returns fail with default feedback on None input."""
-        from canvigator_llm import _parse_assessment
-        result, feedback = _parse_assessment(None)
-        assert result == 'fail'
-
-    def test_case_insensitive_result(self):
-        """Result parsing is case-insensitive."""
-        from canvigator_llm import _parse_assessment
-        result, feedback = _parse_assessment("Result: Pass\nFeedback: OK.")
-        assert result == 'pass'
-
-    def test_unknown_result_defaults_to_fail(self):
-        """Unknown result value defaults to fail."""
-        from canvigator_llm import _parse_assessment
-        result, feedback = _parse_assessment("Result: maybe\nFeedback: Unclear.")
-        assert result == 'fail'
-
-    def test_fallback_uses_whole_response_as_feedback(self):
-        """If no Feedback: line, the whole response becomes feedback."""
-        from canvigator_llm import _parse_assessment
-        result, feedback = _parse_assessment("Result: pass\nThe student did well.")
-        assert result == 'pass'
-        assert 'The student did well' in feedback
-
-
 class TestBuildAssessmentPrompt:
     """Tests for canvigator_llm._build_assessment_prompt."""
 
@@ -1486,12 +1438,13 @@ class TestBuildAssessmentPrompt:
             keywords="binary trees",
             open_ended_question="Draw a binary search tree.",
             original_question_text="What is a BST?",
+            mode='draw',
         )
         assert "binary trees" in result
         assert "transcript" not in result.lower()
 
     def test_includes_assessment_guide(self):
-        """Assessment guide, when provided, appears labeled as the primary rubric."""
+        """Assessment guide is rendered with its instructor-framing label."""
         from canvigator_llm import _build_assessment_prompt
         result = _build_assessment_prompt(
             keywords="binary search",
@@ -1501,7 +1454,6 @@ class TestBuildAssessmentPrompt:
             assessment_guide="Student should mention halving, log n, and sorted input.",
         )
         assert "Assessment guide" in result
-        assert "primary rubric" in result
         assert "halving, log n, and sorted input" in result
 
     def test_omits_empty_assessment_guide(self):
@@ -1515,6 +1467,112 @@ class TestBuildAssessmentPrompt:
             assessment_guide="",
         )
         assert "Assessment guide" not in result
+
+    def test_renders_rubric_block(self):
+        """A rubric dict is rendered as bulleted sections in the prompt."""
+        from canvigator_llm import _build_assessment_prompt
+        rubric = {
+            'canonical_answer': 'Halve the search space each step.',
+            'model_answer': 'Binary search works by dividing the array in half...',
+            'pass_criteria': ['mention halving', 'mention log n'],
+            'acceptable_alternatives': ['logarithmic time'],
+            'common_misconceptions': ['saying it is O(n)'],
+            'fatal_errors': ['claims O(1)'],
+        }
+        result = _build_assessment_prompt(
+            keywords="binary search",
+            open_ended_question="Explain the complexity.",
+            original_question_text="What is the runtime?",
+            transcript="It's logarithmic because we halve each step.",
+            rubric=rubric,
+        )
+        assert "Pass criteria" in result
+        assert "mention halving" in result
+        assert "mention log n" in result
+        assert "Acceptable alternative framings" in result
+        assert "logarithmic time" in result
+        assert "Common misconceptions" in result
+        assert "saying it is O(n)" in result
+        assert "Fatal errors" in result
+        assert "claims O(1)" in result
+        assert "Model answer" in result
+        assert "Canonical answer" in result
+
+    def test_renders_required_visual_elements_for_draw(self):
+        """Draw-mode rubric surfaces required_visual_elements as a checklist."""
+        from canvigator_llm import _build_assessment_prompt
+        rubric = {
+            'canonical_answer': '',
+            'model_answer': '',
+            'pass_criteria': [],
+            'acceptable_alternatives': [],
+            'common_misconceptions': [],
+            'fatal_errors': [],
+            'required_visual_elements': ['root node labeled', 'three child nodes', 'arrows pointing down'],
+        }
+        result = _build_assessment_prompt(
+            keywords="trees",
+            open_ended_question="Draw a tree.",
+            original_question_text="What is a tree?",
+            rubric=rubric,
+            mode='draw',
+        )
+        assert "Required visual elements" in result
+        assert "root node labeled" in result
+        assert "three child nodes" in result
+
+    def test_renders_exemplars_block(self):
+        """Pass/fail exemplars and notes are rendered as a calibration section."""
+        from canvigator_llm import _build_assessment_prompt
+        exemplars = {
+            'exemplar_pass': 'Um, so binary search like cuts the array in half...',
+            'exemplar_pass_note': 'Covers halving and runtime, informal but correct.',
+            'exemplar_fail': 'It just goes through every element.',
+            'exemplar_fail_note': 'Describes linear search, the wrong algorithm.',
+        }
+        result = _build_assessment_prompt(
+            keywords="binary search",
+            open_ended_question="Explain.",
+            original_question_text="What is binary search?",
+            transcript="...",
+            exemplars=exemplars,
+        )
+        assert "Calibration exemplars" in result
+        assert "Passing example" in result
+        assert "cuts the array in half" in result
+        assert "Failing example" in result
+        assert "Describes linear search" in result
+
+    def test_renders_locked_examples(self):
+        """Instructor-approved few-shot examples are rendered when supplied."""
+        from canvigator_llm import _build_assessment_prompt
+        locked = [
+            {'response': 'Binary search halves the array each step.', 'result': 'pass',
+             'feedback': 'Solid — you got the key idea.'},
+            {'response': 'It searches one item at a time.', 'result': 'fail',
+             'feedback': 'You described linear search instead.'},
+        ]
+        result = _build_assessment_prompt(
+            keywords="binary search",
+            open_ended_question="Explain.",
+            original_question_text="What is binary search?",
+            transcript="...",
+            locked_examples=locked,
+        )
+        assert "Previously-graded examples" in result
+        assert "halves the array each step" in result
+        assert "Example 1 verdict: pass" in result
+        assert "searches one item at a time" in result
+        assert "Example 2 verdict: fail" in result
+
+    def test_omits_locked_examples_when_empty(self):
+        """No locked-examples header when the list is empty."""
+        from canvigator_llm import _build_assessment_prompt
+        result = _build_assessment_prompt(
+            keywords="k", open_ended_question="Q", original_question_text="O",
+            transcript="t", locked_examples=[],
+        )
+        assert "Previously-graded examples" not in result
 
 
 class TestBuildAssessmentGuidePrompt:
@@ -1562,3 +1620,481 @@ class TestBuildAssessmentGuidePrompt:
             open_ended_question="Explain the complexity.",
         )
         assert "O(log n)" in result
+
+
+# ---------------------------------------------------------------------------
+# canvigator_llm: structured rubric parser tests (Tier 1B coverage)
+# ---------------------------------------------------------------------------
+
+class TestParseStructuredRubric:
+    """Tests for canvigator_llm._parse_structured_rubric."""
+
+    def _clean_explain_json(self):
+        """Fixture: a minimal valid explain-mode rubric as a JSON string."""
+        return (
+            '{"canonical_answer": "It runs in log time.",'
+            ' "model_answer": "Binary search halves the array each step until found.",'
+            ' "pass_criteria": ["mention halving", "mention sorted input"],'
+            ' "acceptable_alternatives": ["logarithmic"],'
+            ' "common_misconceptions": ["claim O(n)"],'
+            ' "fatal_errors": ["claim O(1)"]}'
+        )
+
+    def test_parses_clean_explain_json(self):
+        """Clean JSON with all explain-mode fields is parsed correctly."""
+        from canvigator_llm import _parse_structured_rubric
+        out = _parse_structured_rubric(self._clean_explain_json(), 'explain')
+        assert out['canonical_answer'] == 'It runs in log time.'
+        assert out['model_answer'].startswith('Binary search halves')
+        assert out['pass_criteria'] == ['mention halving', 'mention sorted input']
+        assert out['acceptable_alternatives'] == ['logarithmic']
+        assert out['common_misconceptions'] == ['claim O(n)']
+        assert out['fatal_errors'] == ['claim O(1)']
+        # Explain mode should NOT have required_visual_elements
+        assert 'required_visual_elements' not in out
+
+    def test_handles_markdown_fences(self):
+        """JSON wrapped in ```json ... ``` fences is unwrapped before parsing."""
+        from canvigator_llm import _parse_structured_rubric
+        wrapped = "```json\n" + self._clean_explain_json() + "\n```"
+        out = _parse_structured_rubric(wrapped, 'explain')
+        assert out['canonical_answer'] == 'It runs in log time.'
+
+    def test_handles_prose_prefix(self):
+        """JSON preceded by prose ('Here is the rubric: {...}') is still parsed."""
+        from canvigator_llm import _parse_structured_rubric
+        prose = "Here is the rubric you asked for: " + self._clean_explain_json() + "\nHope that helps!"
+        out = _parse_structured_rubric(prose, 'explain')
+        assert out['pass_criteria'] == ['mention halving', 'mention sorted input']
+
+    def test_malformed_json_returns_empty_rubric(self):
+        """Garbage in -> empty rubric (no crash, no partial fields)."""
+        from canvigator_llm import _parse_structured_rubric
+        out = _parse_structured_rubric('not json at all', 'explain')
+        assert out['canonical_answer'] == ''
+        assert out['model_answer'] == ''
+        assert out['pass_criteria'] == []
+        assert out['fatal_errors'] == []
+
+    def test_empty_string_returns_empty_rubric(self):
+        """Empty input returns the canonical empty rubric."""
+        from canvigator_llm import _parse_structured_rubric
+        out = _parse_structured_rubric('', 'explain')
+        assert out['pass_criteria'] == []
+
+    def test_draw_mode_includes_required_visual_elements(self):
+        """Draw mode parses required_visual_elements as a list."""
+        from canvigator_llm import _parse_structured_rubric
+        draw_json = (
+            '{"canonical_answer": "Tree with 3 nodes.",'
+            ' "model_answer": "Root at top with two children below.",'
+            ' "pass_criteria": ["root labeled"],'
+            ' "acceptable_alternatives": [],'
+            ' "common_misconceptions": [],'
+            ' "fatal_errors": [],'
+            ' "required_visual_elements": ["root node", "child nodes", "edges"]}'
+        )
+        out = _parse_structured_rubric(draw_json, 'draw')
+        assert out['required_visual_elements'] == ['root node', 'child nodes', 'edges']
+
+    def test_filters_empty_list_items(self):
+        """List entries that are None or empty strings are dropped."""
+        from canvigator_llm import _parse_structured_rubric
+        json_with_empties = (
+            '{"canonical_answer": "X",'
+            ' "model_answer": "",'
+            ' "pass_criteria": ["good", "", "  ", null, "also good"],'
+            ' "acceptable_alternatives": [],'
+            ' "common_misconceptions": [],'
+            ' "fatal_errors": []}'
+        )
+        out = _parse_structured_rubric(json_with_empties, 'explain')
+        assert out['pass_criteria'] == ['good', 'also good']
+
+    def test_non_dict_root_returns_empty(self):
+        """A JSON list (not an object) at the root returns empty rubric."""
+        from canvigator_llm import _parse_structured_rubric
+        out = _parse_structured_rubric('["just a list"]', 'explain')
+        assert out['pass_criteria'] == []
+
+
+# ---------------------------------------------------------------------------
+# canvigator_llm: per-criterion assessment parsing
+# ---------------------------------------------------------------------------
+
+class TestParsePerCriterionResponse:
+    """Tests for canvigator_llm._parse_per_criterion_response."""
+
+    def test_parses_clean_explain_json(self):
+        """A well-formed explain-mode response yields all three sections."""
+        from canvigator_llm import _parse_per_criterion_response
+        resp = (
+            '{"pass_criteria_evaluations": ['
+            '  {"criterion": "mention halving", "status": "met"},'
+            '  {"criterion": "mention sorted input", "status": "missing"}'
+            '],'
+            ' "fatal_errors_evaluations": ['
+            '  {"error": "claim O(1)", "status": "absent"}'
+            '],'
+            ' "feedback": "Solid coverage of halving but you missed sorted input."}'
+        )
+        out = _parse_per_criterion_response(resp, 'explain')
+        assert out['pass_criteria_evaluations'] == [
+            {'criterion': 'mention halving', 'status': 'met'},
+            {'criterion': 'mention sorted input', 'status': 'missing'},
+        ]
+        assert out['fatal_errors_evaluations'] == [
+            {'error': 'claim O(1)', 'status': 'absent'}
+        ]
+        assert 'sorted input' in out['feedback']
+        # explain mode does not have visual_elements
+        assert 'visual_elements_evaluations' not in out
+
+    def test_parses_draw_mode_with_visual_elements(self):
+        """Draw mode parses visual_elements_evaluations."""
+        from canvigator_llm import _parse_per_criterion_response
+        resp = (
+            '{"pass_criteria_evaluations": [],'
+            ' "fatal_errors_evaluations": [],'
+            ' "visual_elements_evaluations": ['
+            '  {"element": "root node", "status": "yes"},'
+            '  {"element": "edges", "status": "no"}'
+            '],'
+            ' "feedback": "Root is there but no edges."}'
+        )
+        out = _parse_per_criterion_response(resp, 'draw')
+        assert out['visual_elements_evaluations'] == [
+            {'element': 'root node', 'status': 'yes'},
+            {'element': 'edges', 'status': 'no'},
+        ]
+
+    def test_handles_markdown_fences(self):
+        """Fenced JSON output is unwrapped before parsing."""
+        from canvigator_llm import _parse_per_criterion_response
+        resp = (
+            '```json\n'
+            '{"pass_criteria_evaluations": [{"criterion": "X", "status": "met"}],'
+            ' "fatal_errors_evaluations": [],'
+            ' "feedback": "ok"}'
+            '\n```'
+        )
+        out = _parse_per_criterion_response(resp, 'explain')
+        assert out['pass_criteria_evaluations'][0]['status'] == 'met'
+
+    def test_invalid_status_degrades_to_worst_case(self):
+        """A bogus status value never silently flips to a charitable default."""
+        from canvigator_llm import _parse_per_criterion_response
+        resp = (
+            '{"pass_criteria_evaluations": [{"criterion": "X", "status": "kinda met"}],'
+            ' "fatal_errors_evaluations": [{"error": "Y", "status": "maybe"}],'
+            ' "feedback": "test"}'
+        )
+        out = _parse_per_criterion_response(resp, 'explain')
+        assert out['pass_criteria_evaluations'][0]['status'] == 'missing'
+        assert out['fatal_errors_evaluations'][0]['status'] == 'present'
+
+    def test_malformed_returns_empty_shape(self):
+        """Malformed JSON returns the canonical empty shape, not a crash."""
+        from canvigator_llm import _parse_per_criterion_response
+        out = _parse_per_criterion_response('not json', 'explain')
+        assert out['pass_criteria_evaluations'] == []
+        assert out['fatal_errors_evaluations'] == []
+        assert out['feedback'] == ''
+
+
+class TestAggregatePassFail:
+    """Tests for canvigator_llm._aggregate_pass_fail."""
+
+    def test_all_met_passes(self):
+        """All pass criteria met, no fatal errors -> pass."""
+        from canvigator_llm import _aggregate_pass_fail
+        evals = {
+            'pass_criteria_evaluations': [
+                {'criterion': 'a', 'status': 'met'},
+                {'criterion': 'b', 'status': 'met'},
+            ],
+            'fatal_errors_evaluations': [{'error': 'x', 'status': 'absent'}],
+        }
+        assert _aggregate_pass_fail(evals, 'explain') == 'pass'
+
+    def test_all_missing_fails(self):
+        """All criteria missing -> fail."""
+        from canvigator_llm import _aggregate_pass_fail
+        evals = {
+            'pass_criteria_evaluations': [
+                {'criterion': 'a', 'status': 'missing'},
+                {'criterion': 'b', 'status': 'missing'},
+            ],
+            'fatal_errors_evaluations': [],
+        }
+        assert _aggregate_pass_fail(evals, 'explain') == 'fail'
+
+    def test_partial_credit_at_threshold(self):
+        """Two partial out of two = 0.5 score = exact threshold = pass."""
+        from canvigator_llm import _aggregate_pass_fail
+        evals = {
+            'pass_criteria_evaluations': [
+                {'criterion': 'a', 'status': 'partial'},
+                {'criterion': 'b', 'status': 'partial'},
+            ],
+            'fatal_errors_evaluations': [],
+        }
+        assert _aggregate_pass_fail(evals, 'explain') == 'pass'
+
+    def test_below_threshold_fails(self):
+        """One partial + one missing = 0.25 score = below threshold -> fail."""
+        from canvigator_llm import _aggregate_pass_fail
+        evals = {
+            'pass_criteria_evaluations': [
+                {'criterion': 'a', 'status': 'partial'},
+                {'criterion': 'b', 'status': 'missing'},
+            ],
+            'fatal_errors_evaluations': [],
+        }
+        assert _aggregate_pass_fail(evals, 'explain') == 'fail'
+
+    def test_fatal_error_forces_fail(self):
+        """A fatal error present forces fail, even with all criteria met."""
+        from canvigator_llm import _aggregate_pass_fail
+        evals = {
+            'pass_criteria_evaluations': [
+                {'criterion': 'a', 'status': 'met'},
+                {'criterion': 'b', 'status': 'met'},
+            ],
+            'fatal_errors_evaluations': [{'error': 'x', 'status': 'present'}],
+        }
+        assert _aggregate_pass_fail(evals, 'explain') == 'fail'
+
+    def test_empty_criteria_passes(self):
+        """No pass criteria + no fatal errors -> pass (default 1.0 score)."""
+        from canvigator_llm import _aggregate_pass_fail
+        evals = {'pass_criteria_evaluations': [], 'fatal_errors_evaluations': []}
+        assert _aggregate_pass_fail(evals, 'explain') == 'pass'
+
+    def test_draw_mode_visual_elements_below_threshold_fails(self):
+        """Draw mode: visual elements below threshold forces fail even if criteria met."""
+        from canvigator_llm import _aggregate_pass_fail
+        evals = {
+            'pass_criteria_evaluations': [{'criterion': 'a', 'status': 'met'}],
+            'fatal_errors_evaluations': [],
+            'visual_elements_evaluations': [
+                {'element': 'x', 'status': 'no'},
+                {'element': 'y', 'status': 'no'},
+            ],
+        }
+        assert _aggregate_pass_fail(evals, 'draw') == 'fail'
+
+    def test_draw_mode_unclear_counts_as_half(self):
+        """Draw mode: unclear visual elements count as 0.5."""
+        from canvigator_llm import _aggregate_pass_fail
+        evals = {
+            'pass_criteria_evaluations': [{'criterion': 'a', 'status': 'met'}],
+            'fatal_errors_evaluations': [],
+            'visual_elements_evaluations': [
+                {'element': 'x', 'status': 'unclear'},
+                {'element': 'y', 'status': 'unclear'},
+            ],
+        }
+        # 0.5 + 0.5 = 1.0 / 2 = 0.5 exactly = pass
+        assert _aggregate_pass_fail(evals, 'draw') == 'pass'
+
+    def test_draw_mode_no_visual_elements_defaults_to_pass_score(self):
+        """Empty visual elements list defaults visual score to 1.0 (auto-pass on that axis)."""
+        from canvigator_llm import _aggregate_pass_fail
+        evals = {
+            'pass_criteria_evaluations': [{'criterion': 'a', 'status': 'met'}],
+            'fatal_errors_evaluations': [],
+            'visual_elements_evaluations': [],
+        }
+        assert _aggregate_pass_fail(evals, 'draw') == 'pass'
+
+
+class TestVoteAssessments:
+    """Tests for canvigator_llm._vote_assessments."""
+
+    def test_unanimous_pass_yields_high_confidence(self):
+        """3-0 pass -> result=pass, confidence=high."""
+        from canvigator_llm import _vote_assessments
+        runs = [
+            ('pass', 'Good.', {'pass_criteria_evaluations': []}),
+            ('pass', 'Solid.', {'pass_criteria_evaluations': []}),
+            ('pass', 'OK.', {'pass_criteria_evaluations': []}),
+        ]
+        result, confidence, feedback, _ = _vote_assessments(runs)
+        assert result == 'pass'
+        assert confidence == 'high'
+        assert feedback == 'Good.'  # First matching run's feedback
+
+    def test_majority_pass_yields_borderline(self):
+        """2-1 pass -> result=pass, confidence=borderline."""
+        from canvigator_llm import _vote_assessments
+        runs = [
+            ('fail', 'Off-topic.', {}),
+            ('pass', 'Mostly there.', {}),
+            ('pass', 'Acceptable.', {}),
+        ]
+        result, confidence, feedback, _ = _vote_assessments(runs)
+        assert result == 'pass'
+        assert confidence == 'borderline'
+        assert feedback == 'Mostly there.'  # First matching run
+
+    def test_majority_fail_yields_borderline(self):
+        """1-2 fail -> result=fail, confidence=borderline."""
+        from canvigator_llm import _vote_assessments
+        runs = [
+            ('pass', 'Looks good.', {}),
+            ('fail', 'Missed it.', {}),
+            ('fail', 'Off-topic.', {}),
+        ]
+        result, confidence, feedback, _ = _vote_assessments(runs)
+        assert result == 'fail'
+        assert confidence == 'borderline'
+        assert feedback == 'Missed it.'
+
+    def test_empty_runs_returns_fail(self):
+        """Empty runs list returns a sane fail default."""
+        from canvigator_llm import _vote_assessments
+        result, confidence, feedback, _ = _vote_assessments([])
+        assert result == 'fail'
+        assert 'No assessment runs' in feedback
+
+
+# ---------------------------------------------------------------------------
+# canvigator_llm: exemplar parsing
+# ---------------------------------------------------------------------------
+
+class TestParseExemplars:
+    """Tests for canvigator_llm._parse_exemplars."""
+
+    def test_parses_clean_json(self):
+        """All four exemplar fields are extracted from a clean JSON object."""
+        from canvigator_llm import _parse_exemplars
+        resp = (
+            '{"exemplar_pass": "It halves the array each step.",'
+            ' "exemplar_pass_note": "Captures the core idea.",'
+            ' "exemplar_fail": "It looks at every element.",'
+            ' "exemplar_fail_note": "Describes linear search instead."}'
+        )
+        out = _parse_exemplars(resp)
+        assert out['exemplar_pass'] == 'It halves the array each step.'
+        assert out['exemplar_pass_note'] == 'Captures the core idea.'
+        assert out['exemplar_fail'] == 'It looks at every element.'
+        assert out['exemplar_fail_note'] == 'Describes linear search instead.'
+
+    def test_handles_fences(self):
+        """Markdown fences are stripped."""
+        from canvigator_llm import _parse_exemplars
+        resp = '```json\n{"exemplar_pass": "X", "exemplar_pass_note": "", "exemplar_fail": "", "exemplar_fail_note": ""}\n```'
+        out = _parse_exemplars(resp)
+        assert out['exemplar_pass'] == 'X'
+
+    def test_malformed_returns_empty(self):
+        """Malformed JSON returns the empty exemplar dict."""
+        from canvigator_llm import _parse_exemplars
+        out = _parse_exemplars('not json')
+        assert out == {
+            'exemplar_pass': '', 'exemplar_pass_note': '',
+            'exemplar_fail': '', 'exemplar_fail_note': '',
+        }
+
+
+# ---------------------------------------------------------------------------
+# canvigator_quiz: locked-example sampler (Tier 3C)
+# ---------------------------------------------------------------------------
+
+class TestCollectLockedExamples:
+    """Tests for CanvigatorQuiz._collectLockedExamples."""
+
+    def _stub(self):
+        """Return a CanvigatorQuiz stand-in carrying just _collectLockedExamples."""
+        from canvigator_quiz import CanvigatorQuiz
+
+        class _Stub:
+            LOCKED_EXAMPLES_PER_BUCKET = CanvigatorQuiz.LOCKED_EXAMPLES_PER_BUCKET
+            _collectLockedExamples = CanvigatorQuiz._collectLockedExamples
+
+        return _Stub()
+
+    def _df(self, rows):
+        """Build an assessments DataFrame from row dicts."""
+        from canvigator_quiz import CanvigatorQuiz
+        return pd.DataFrame(rows, columns=CanvigatorQuiz.ASSESSMENTS_COLUMNS)
+
+    def _row(self, sid, qid, result, transcript, sent=1, mode='explain', feedback='fb'):
+        """Convenience row builder."""
+        return {
+            'student_id': sid, 'student_name': f's{sid}', 'question_id': qid,
+            'question_mode': mode, 'conversation_id': 100 + sid,
+            'result': result, 'confidence': 'high', 'feedback': feedback,
+            'transcript': transcript, 'criteria_evaluations': '',
+            'assessed_at': '', 'sent_assessment': sent, 'sent_at': '',
+        }
+
+    def test_empty_df_returns_empty(self):
+        """An empty DataFrame yields no examples."""
+        from canvigator_quiz import CanvigatorQuiz
+        out = self._stub()._collectLockedExamples(
+            pd.DataFrame(columns=CanvigatorQuiz.ASSESSMENTS_COLUMNS), 42,
+        )
+        assert out == []
+
+    def test_only_includes_sent_assessments(self):
+        """sent_assessment=0 rows are skipped."""
+        df = self._df([
+            self._row(1, 42, 'pass', 'good response', sent=1),
+            self._row(2, 42, 'pass', 'also good', sent=0),
+        ])
+        out = self._stub()._collectLockedExamples(df, 42)
+        responses = [e['response'] for e in out]
+        assert 'good response' in responses
+        assert 'also good' not in responses
+
+    def test_only_includes_matching_question_id(self):
+        """Rows for a different question_id are filtered out."""
+        df = self._df([
+            self._row(1, 42, 'pass', 'matches'),
+            self._row(2, 99, 'pass', 'wrong question'),
+        ])
+        out = self._stub()._collectLockedExamples(df, 42)
+        responses = [e['response'] for e in out]
+        assert responses == ['matches']
+
+    def test_skips_rows_with_empty_transcript(self):
+        """Rows whose transcript is empty (e.g. draw mode) are skipped."""
+        df = self._df([
+            self._row(1, 42, 'pass', '', mode='draw'),
+            self._row(2, 42, 'pass', 'has text'),
+        ])
+        out = self._stub()._collectLockedExamples(df, 42)
+        responses = [e['response'] for e in out]
+        assert responses == ['has text']
+
+    def test_skips_draw_mode_even_with_transcript(self):
+        """Draw mode is filtered before sampling, regardless of transcript."""
+        df = self._df([
+            self._row(1, 42, 'pass', 'something', mode='draw'),
+            self._row(2, 42, 'pass', 'explain text', mode='explain'),
+        ])
+        out = self._stub()._collectLockedExamples(df, 42)
+        responses = [e['response'] for e in out]
+        assert responses == ['explain text']
+
+    def test_returns_both_passes_and_fails(self):
+        """Both pass and fail buckets are sampled."""
+        df = self._df([
+            self._row(1, 42, 'pass', 'pass-resp'),
+            self._row(2, 42, 'fail', 'fail-resp'),
+        ])
+        out = self._stub()._collectLockedExamples(df, 42)
+        results = sorted(e['result'] for e in out)
+        assert results == ['fail', 'pass']
+
+    def test_caps_per_bucket(self):
+        """No more than LOCKED_EXAMPLES_PER_BUCKET examples per result label."""
+        from canvigator_quiz import CanvigatorQuiz
+        cap = CanvigatorQuiz.LOCKED_EXAMPLES_PER_BUCKET
+        rows = [self._row(i, 42, 'pass', f'resp{i}') for i in range(cap + 4)]
+        df = self._df(rows)
+        out = self._stub()._collectLockedExamples(df, 42)
+        passes = [e for e in out if e['result'] == 'pass']
+        assert len(passes) == cap


### PR DESCRIPTION
## Summary

Gemini already generated a structured JSON rubric per follow-up question and saved it to `*_open_ended_*.csv`, but `assess_replies()` only consumed the prose `assessment_guide` — the structured rubric was orphaned. This wires the rubric end-to-end and gives Gemma more scaffolding so its job is closer to checklist matching than open-ended judgment.

- **Tier 1A — Consume `rubric_json` in the assessment prompt.** Pluck the parsed rubric from the open-ended row and render `pass_criteria`, `acceptable_alternatives`, `common_misconceptions`, `fatal_errors`, `canonical_answer`, and (draw mode) `required_visual_elements` as a structured block in Gemma's user prompt.
- **Tier 2A — `model_answer`.** Add an 80–120 word fully-developed exemplar response to the rubric schema so Gemma has a concrete reference point for register, depth, and completeness.
- **Tier 2B — Gemini-authored exemplars.** Generate one passing + one failing fake student response per follow-up question at generation time; persist `exemplar_pass`, `exemplar_pass_note`, `exemplar_fail`, `exemplar_fail_note` columns and inject as few-shot examples at assessment time.
- **Tier 3A — Per-criterion JSON + deterministic aggregation.** Ask Gemma to label each `pass_criteria` item `met`/`partial`/`missing`, each fatal error `present`/`absent`, and (draw mode) each visual element `yes`/`no`/`unclear`. Pass/fail aggregated in Python: `pass_score >= 0.5` AND no fatal errors AND (draw) `visual_score >= 0.5`. Bogus statuses degrade to worst case.
- **Tier 3B — Self-consistency voting.** Run Gemma N=3 with majority vote; record `confidence` (`high` if unanimous, `borderline` if 2-1) and `criteria_evaluations` JSON in the persistent assessments CSV.
- **Tier 3C — Calibration loop.** Sample `sent_assessment=1` rows from the persistent assessments CSV and inject them as instructor-curated few-shot examples for future runs of the same `question_id` (explain mode only — draw mode transcripts are empty). Stays local; only instructor-vetted student data is reused.

Tier 4 items (ASR replacement, transcript-quality flags, question-quality signal back to instructor) are intentionally out of scope.

New columns:
- `*_open_ended_*.csv`: `exemplar_pass`, `exemplar_pass_note`, `exemplar_fail`, `exemplar_fail_note` (and `model_answer` inside `rubric_json`)
- `*_followup_assessments.csv`: `confidence`, `criteria_evaluations`

## Test plan

End-to-end retest (cannot be run until students reply to a real follow-up):
- [x] `python canvigator.py get-quiz-questions --tag` — confirm `*_questions_w_tags_*.csv` still writes correctly
- [x] `python canvigator.py generate-follow-up-questions` — confirm new exemplar columns appear and `model_answer` is present inside `rubric_json`
- [ ] `python canvigator.py send-follow-up-question --dry-run` then live send
- [ ] `python canvigator.py assess-replies` — confirm new `confidence` and `criteria_evaluations` columns; ~3× wall-clock per reply due to N=3 voting
- [ ] After locking some assessments (`sent_assessment=1`), re-run `assess-replies` — should print "Using N instructor-approved example(s) for calibration."
- [ ] `python canvigator.py send-follow-up-assessments`

Already verified locally:
- [x] `python -m pytest test_canvigator.py -v` — 178/178 pass
- [x] Both flake8 commands clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)