### PR TITLE
Send consolidated quiz reminders via --all on send-quiz-reminder

### DIFF
--- a/canvigator.py
+++ b/canvigator.py
@@ -41,7 +41,7 @@ def print_help():
     print("Options (short and long forms are interchangeable):")
     print("  -d, --dry-run                Preview changes without modifying Canvas (applies to bonus, reminder, follow-up, feedback, delete-old-conversations)")
     print("  -t, --tag                    Use a cloud LLM via Ollama to tag questions (get-quiz-questions only)")
-    print("  -a, --all                    Run across every quiz in the course (get-quiz-questions and get-quiz-submission-events only)")
+    print("  -a, --all                    Run across every quiz in the course (get-quiz-questions, get-quiz-submission-events, send-quiz-reminder)")
     print("  -c, --crn <CRN>              Select course by CRN (last 5 digits of course code)")
     print("  -m, --months <N>             Age threshold in months for delete-old-conversations (default: 6)")
     print("  -w, --reply-window-days <N>  Days to accept replies after follow-up sent (default: 5, assess-replies only)")
@@ -271,6 +271,9 @@ if task == 'get-activity':
 
 elif task == 'get-quiz-submission-events' and all_quizzes_flag:
     course.getAllQuizzesAndSubmissions()
+
+elif task == 'send-quiz-reminder' and all_quizzes_flag:
+    course.sendAllQuizReminders(dry_run=dry_run)
 
 elif task == 'create-quiz':
     course.createQuiz()

--- a/canvigator_course.py
+++ b/canvigator_course.py
@@ -606,19 +606,41 @@ class CanvigatorCourse:
                                            'used_mobile_app', 'n_distinct_user_agents'])
 
 
+def _indentBulletsAsSub(bullets_text):
+    r"""Convert a single-quiz bullet block into a 2-space-indented sub-bullet block.
+
+    The renderers produce a block like ``"\n\n<preamble>:\n• Q1...\n• Q2..."``.
+    When that block is nested under a quiz section header in a multi-quiz
+    consolidated message, the preamble is redundant (the header already conveys
+    context) and the bullets need to read as sub-items. This drops the preamble
+    and indents every ``•`` line with two spaces.
+    """
+    if not bullets_text:
+        return ''
+    sub_lines = ['  ' + ln for ln in bullets_text.splitlines() if ln.startswith('•')]
+    if not sub_lines:
+        return ''
+    return '\n' + '\n'.join(sub_lines)
+
+
 def _composeMultiQuizReminder(first_name, state_list):
     """Render a consolidated reminder body for one student covering multiple quizzes.
 
     ``state_list`` is an ordered list of dicts with keys ``quiz_name``,
     ``due_at``, ``points_possible``, ``reason``, ``bullets`` (already-rendered
-    bullet block or ``None``). Sections are emitted in the order provided.
+    bullet block or ``None``). Sections are emitted in the order provided. When
+    the message covers more than one quiz, per-question bullets are rendered as
+    2-space-indented sub-bullets of their quiz section header.
     """
+    nested = len(state_list) > 1
     sections = []
     for s in state_list:
         due_str = format_due_date(s.get('due_at'))
         quiz_name = s.get('quiz_name', '')
         reason = s.get('reason', '')
         bullets = s.get('bullets') or ''
+        if nested:
+            bullets = _indentBulletsAsSub(bullets)
 
         if reason == 'no attempt':
             head = f"• {quiz_name} (due {due_str}) — not yet attempted"

--- a/canvigator_course.py
+++ b/canvigator_course.py
@@ -5,7 +5,8 @@ from collections import Counter
 from datetime import datetime, timedelta, timezone
 import pandas as pd
 import canvigator_quiz as cq
-from canvigator_utils import today_str, spin, spin_done
+import canvigator_utils as cu
+from canvigator_utils import today_str, spin, spin_done, format_due_date
 
 MAX_COURSE_WEEKS = 16
 
@@ -57,6 +58,100 @@ class CanvigatorCourse:
                 quiz.generateFirstAttemptHistograms()
             else:
                 print("  Skipping (unpublished or insufficient submissions)")
+
+    def sendAllQuizReminders(self, dry_run=False):
+        """Send one consolidated reminder per student covering every published, future-due quiz they're behind on.
+
+        Iterates every quiz passing ``cu.is_quiz_open_for_reminder`` (published
+        with a ``due_at`` strictly in the future), classifies each enrolled
+        student per quiz (no attempt / imperfect / page-blur on perfect), and
+        composes a single message per student listing all eligible quizzes.
+        Skips quizzes lacking a ``*_questions_w_tags_*.csv`` with a warning.
+        """
+        all_quizzes = list(self.canvas_course.get_quizzes())
+        eligible = [q for q in all_quizzes if cu.is_quiz_open_for_reminder(q)]
+
+        if not eligible:
+            print("\nNo published quizzes with a future due date were found.")
+            logger.info("sendAllQuizReminders: no eligible quizzes")
+            return
+
+        # Earliest-due first so messages list quizzes in chronological order.
+        eligible.sort(key=lambda q: getattr(q, 'due_at', '') or '')
+
+        print(f"\nFound {len(eligible)} eligible quiz(zes) (published, future-due).")
+
+        # student_id -> list[dict(quiz_id, quiz_name, due_at, reason, bullets)]
+        student_state = {}
+
+        for i, q in enumerate(eligible, start=1):
+            print(f"\n[{i}/{len(eligible)}] Processing: {q.title}")
+            quiz = cq.CanvigatorQuiz(self.canvas, self, q, self.config, self.verbose)
+
+            try:
+                question_info = quiz._loadQuestionInfo()
+            except FileNotFoundError as e:
+                msg = f"Skipping '{q.title}' — {e}"
+                print(f"  WARNING: {msg}")
+                logger.warning(msg)
+                continue
+
+            print("  Fetching latest submissions...")
+            quiz.getAllSubmissionsAndEvents()
+            subs_by_q_df = quiz.all_subs_by_question
+            events_df = quiz.all_subs_and_events
+            quiz_scores = quiz._buildQuizScores()
+            points_possible = q.points_possible
+
+            for student in self.students:
+                student_id = student['id']
+                classification = quiz._classifyStudentForQuiz(
+                    student_id, quiz_scores, points_possible, subs_by_q_df, events_df, question_info,
+                )
+                if classification is None:
+                    continue
+                reason, bullets = classification
+                student_state.setdefault(student_id, []).append({
+                    'quiz_id': q.id,
+                    'quiz_name': q.title,
+                    'due_at': getattr(q, 'due_at', None),
+                    'points_possible': points_possible,
+                    'reason': reason,
+                    'bullets': bullets,
+                })
+
+        if not student_state:
+            print("\nAll students are caught up — no consolidated reminders to send.")
+            logger.info("sendAllQuizReminders: no students with reminder-worthy state")
+            return
+
+        enrolled_map = {s['id']: s['name'] for s in self.students}
+        subject_str = cq._composeConversationSubject(
+            self.canvas_course.course_code, "Quiz Reminder", "", short_code=True,
+        )
+
+        messages = []
+        for student_id, state_list in student_state.items():
+            student_name = enrolled_map.get(student_id, "")
+            if not student_name:
+                continue
+            first_name = student_name.split()[0]
+            message_str = _composeMultiQuizReminder(first_name, state_list)
+            reasons_summary = "; ".join(s['reason'] for s in state_list)
+            messages.append((student_id, student_name, message_str, reasons_summary))
+
+        header_label = (
+            f"Course: {self.canvas_course.course_code} "
+            f"(consolidated reminder covering {len(eligible)} quiz(zes))"
+        )
+
+        if dry_run:
+            cq._sendOrPreviewMessages(messages, subject_str, header_label)
+            _saveCourseReminderManifest(messages, student_state, subject_str, dry_run, self.config.data_path)
+        else:
+            sent_messages = cq._interactiveSend(self.canvas, messages, subject_str, header_label)
+            if sent_messages:
+                _saveCourseReminderManifest(sent_messages, student_state, subject_str, dry_run, self.config.data_path)
 
     def createQuiz(self):
         """Create a new placeholder quiz with stub questions on Canvas."""
@@ -509,6 +604,91 @@ class CanvigatorCourse:
             })
         return pd.DataFrame(rows, columns=['id', 'top_browser', 'top_os',
                                            'used_mobile_app', 'n_distinct_user_agents'])
+
+
+def _composeMultiQuizReminder(first_name, state_list):
+    """Render a consolidated reminder body for one student covering multiple quizzes.
+
+    ``state_list`` is an ordered list of dicts with keys ``quiz_name``,
+    ``due_at``, ``points_possible``, ``reason``, ``bullets`` (already-rendered
+    bullet block or ``None``). Sections are emitted in the order provided.
+    """
+    sections = []
+    for s in state_list:
+        due_str = format_due_date(s.get('due_at'))
+        quiz_name = s.get('quiz_name', '')
+        reason = s.get('reason', '')
+        bullets = s.get('bullets') or ''
+
+        if reason == 'no attempt':
+            head = f"• {quiz_name} (due {due_str}) — not yet attempted"
+        elif reason == 'page blur':
+            head = (
+                f"• {quiz_name} (due {due_str}) — perfect score, "
+                "but the quiz window appears to have been left during your most recent attempt"
+            )
+        elif reason == 'perfect clean':
+            head = (
+                f"• {quiz_name} (due {due_str}) — nice work, perfect score with no "
+                "window changes; still not due, so consider retaking to confirm retention"
+            )
+        else:
+            # 'score x/y'
+            head = f"• {quiz_name} (due {due_str}) — {reason}"
+
+        sections.append(head + bullets)
+
+    note_str = (
+        "\n\nNOTE: This is an auto-generated message that is currently being tested to see "
+        "whether it helps encourage students to (re)take a quiz, so please let me know if "
+        "you have any questions, concerns, or suggestions about it."
+    )
+
+    intro = (
+        f"Hello {first_name},\n\n"
+        "Below are currently active quizzes that you may want to revisit before they're due:\n\n"
+    )
+    closing = (
+        "\n\nQuizzes are most effective as learning tools when you try to answer the "
+        "questions on your own without using outside references or AI tools — embrace the "
+        "struggle, that's where the learning happens. Good luck!"
+    )
+    return intro + "\n\n".join(sections) + closing + note_str
+
+
+def _saveCourseReminderManifest(messages, student_state, subject_str, dry_run, data_path):
+    """Save the combined course-level manifest for a `--all` send-quiz-reminder run.
+
+    One row per student-message; ``quiz_ids`` / ``quiz_names`` / ``reasons`` are
+    pipe-delimited in due-date order matching the rendered message.
+    """
+    sent_at = datetime.now(timezone.utc).isoformat()
+    rows = []
+    for entry in messages:
+        if len(entry) == 5:
+            student_id, student_name, _, _, convo_id = entry
+        else:
+            student_id, student_name, _, _ = entry
+            convo_id = None
+        state_list = student_state.get(student_id, [])
+        rows.append({
+            'student_id': student_id,
+            'student_name': student_name,
+            'quiz_count': len(state_list),
+            'quiz_ids': '|'.join(str(s['quiz_id']) for s in state_list),
+            'quiz_names': '|'.join(s['quiz_name'] for s in state_list),
+            'reasons': '|'.join(s['reason'] for s in state_list),
+            'conversation_id': convo_id,
+            'conversation_subject': subject_str,
+            'sent_at': sent_at,
+        })
+
+    manifest_df = pd.DataFrame(rows)
+    suffix = "_dryrun" if dry_run else ""
+    csv_name = data_path / f"course_reminder_sent{suffix}_{today_str()}.csv"
+    manifest_df.to_csv(csv_name, index=False)
+    print(f"  Manifest saved: {csv_name.name}")
+    logger.info(f"Course-level reminder manifest saved: {csv_name}")
 
 
 def _collectOldConversations(canvas, cutoff_dt, current_user_id):

--- a/canvigator_llm.py
+++ b/canvigator_llm.py
@@ -90,17 +90,28 @@ _CLASSIFY_SYSTEM_PROMPT = (
     "Respond with ONLY the single word \"explain\" or \"draw\" — nothing else."
 )
 
+_STANDALONE_RULE = (
+    "- Be FULLY STAND-ALONE and ISOLATED — write each question so that a student who has "
+    "never seen (or has completely forgotten) the original quiz question can read your "
+    "question on its own and know exactly what is being asked. Re-state every entity, "
+    "scenario, variable, dataset, function name, or example that the question depends on. "
+    "Do NOT use phrases like \"the previous question\", \"as shown above\", \"recall the "
+    "scenario\", \"this method/function/algorithm/figure\", \"the question on the quiz\", "
+    "or any pronoun whose referent appears only in the original quiz question. If you find "
+    "yourself relying on context from the original, inline that context into your question "
+    "instead\n"
+)
+
 _EXPLAIN_SYSTEM_PROMPT = (
     "You are an expert university instructor designing oral exam questions. "
     "Given a topic and details from an existing quiz question, create THREE distinct "
-    "open-ended questions that a student would answer verbally. Each question should:\n"
+    "open-ended questions that a student would answer verbally. Each question should:\n" +
+    _STANDALONE_RULE +
     "- Begin with \"Explain\" and require the student to explain a concept or idea clearly "
     "in their own words\n"
     "- Be answerable in under 1 minute of speaking\n"
     "- Test understanding, not memorization — the student should demonstrate they grasp "
     "the underlying idea, not just recall a definition\n"
-    "- Be self-contained (a student should understand what is being asked without seeing "
-    "the original quiz question)\n"
     "- NOT be a yes/no question or a question that can be answered in one word\n\n"
     "The three questions must cover DIFFERENT angles, framings, or sub-aspects of the concept — "
     "do not reword the same question three times.\n\n"
@@ -111,13 +122,12 @@ _EXPLAIN_SYSTEM_PROMPT = (
 _DRAW_SYSTEM_PROMPT = (
     "You are an expert university instructor designing visual assessment questions. "
     "Given a topic and details from an existing quiz question, create THREE distinct "
-    "questions that ask a student to draw a diagram or figure by hand. Each question should:\n"
+    "questions that ask a student to draw a diagram or figure by hand. Each question should:\n" +
+    _STANDALONE_RULE +
     "- Begin with \"Draw a diagram\" or \"Draw a figure\" and clearly describe what the "
     "student should illustrate\n"
     "- Be completable in under 2 minutes of drawing\n"
     "- Test understanding of structure, relationships, or processes — not artistic skill\n"
-    "- Be self-contained (a student should understand what is being asked without seeing "
-    "the original quiz question)\n"
     "- Specify what key elements or labels should appear in the diagram\n\n"
     "The three questions must cover DIFFERENT angles, framings, or sub-aspects of the concept — "
     "do not reword the same question three times.\n\n"
@@ -371,10 +381,21 @@ def _build_open_ended_prompt(keywords, question_text, answers_json, mode):
     if keywords:
         parts.append(f"Topic keywords: {keywords}")
     if clean_text:
-        parts.append(f"Original question: {clean_text}")
+        parts.append(
+            "Original quiz question (BACKGROUND CONTEXT ONLY — do NOT reference, quote, "
+            f"or allude to it in your output): {clean_text}"
+        )
     if labels:
         joined = " | ".join(labels[:6])
-        parts.append(f"Answer choices from the original: {joined}")
+        parts.append(
+            f"Answer choices from the original (background only, do NOT reference): {joined}"
+        )
+    parts.append(
+        "REMINDER: Each of your three questions must stand entirely on its own — a reader "
+        "who has never seen the material above must be able to understand and answer it from "
+        "the question text alone. Inline any needed scenario, variables, or example data "
+        "directly into the question."
+    )
     if mode == "draw":
         parts.append("Visual assessment question (must start with \"Draw a diagram\" or \"Draw a figure\"):")
     else:

--- a/canvigator_quiz.py
+++ b/canvigator_quiz.py
@@ -14,7 +14,7 @@ import os
 import re
 import json
 from pathlib import Path
-from canvigator_utils import today_str, selectCSVFromList, prompt_for_index, find_latest_csv, spin, spin_done
+from canvigator_utils import today_str, selectCSVFromList, prompt_for_index, find_latest_csv, spin, spin_done, format_due_date
 
 logger = logging.getLogger(__name__)
 
@@ -309,6 +309,98 @@ def generateOpenEndedQuestions(tagged_csv_path):
     logger.info(f"Open-ended questions saved: {csv_name}")
 
 
+def _sendOrPreviewMessages(messages, subject_str, header_label):
+    """Preview the collected messages in dry-run mode and print a summary.
+
+    `header_label` is the one-line context string shown above the previews
+    (e.g. "Quiz: <name> (<pts> points possible)" or
+    "Course: <code> (consolidated reminder for N quiz(zes))").
+    """
+    if not messages:
+        print("No reminders to send.")
+        return
+
+    print("\n=== DRY RUN MODE - No messages will be sent on Canvas ===\n")
+
+    print(header_label)
+    print(f"Reminders to send: {len(messages)}\n")
+
+    for student_id, student_name, message_str, reason in messages:
+        print(f"  [DRY RUN] To: {student_name} (id: {student_id}, {reason})")
+        print(f"            Subject: {subject_str}")
+        print(f"            Message: {message_str}\n")
+
+    # Categories may overlap when one consolidated message covers multiple
+    # quizzes with different reasons (e.g. "no attempt; page blur"), so the
+    # counts are independent — they don't sum to len(messages).
+    n_no_attempt = sum(1 for _, _, _, r in messages if 'no attempt' in r)
+    n_blur = sum(1 for _, _, _, r in messages if 'page blur' in r)
+    n_perfect_clean = sum(1 for _, _, _, r in messages if 'perfect clean' in r)
+    n_imperfect = sum(1 for _, _, _, r in messages if 'score ' in r)
+    summary_parts = []
+    if n_no_attempt:
+        summary_parts.append(f"{n_no_attempt} containing no-attempt")
+    if n_imperfect:
+        summary_parts.append(f"{n_imperfect} containing imperfect-score")
+    if n_blur:
+        summary_parts.append(f"{n_blur} containing page-blur")
+    if n_perfect_clean:
+        summary_parts.append(f"{n_perfect_clean} containing perfect-clean")
+    if summary_parts:
+        print(f"\n{len(messages)} reminder(s) would be sent ({', '.join(summary_parts)}).")
+    else:
+        print(f"\n{len(messages)} reminder(s) would be sent.")
+    logger.info(f"Quiz reminders (dry run) would be sent: {len(messages)}")
+
+
+def _interactiveSend(canvas, messages, subject_str, header_label):
+    """Interactively prompt the instructor to send or skip each message.
+
+    Default behavior is SKIP — the message is sent if and only if the user
+    types ``y`` (case-insensitive) and presses Enter. Any other input,
+    including a bare Enter, skips. Returns the list of messages that were
+    actually sent as 5-tuples (..., conversation_id).
+    """
+    if not messages:
+        print("No messages to send!")
+        return []
+
+    print(f"\n{header_label}")
+    print(f"Messages to review: {len(messages)}")
+    print("For each student, enter 'y' + Enter to send, or just Enter to skip (default).\n")
+
+    sent_messages = []
+    for i, (student_id, student_name, message_str, reason) in enumerate(messages, 1):
+        print(f"--- Student {i}/{len(messages)} ---")
+        print(f"  To: {student_name} (id: {student_id}, {reason})")
+        print(f"  Subject: {subject_str}")
+        print(f"  Message: {message_str}\n")
+
+        # Strict 'y' check — N is the default; anything other than 'y' (case-insensitive)
+        # skips. This includes 'yes', 'send', 'Y', empty, etc. — only a single 'y' sends.
+        choice = input(f"  Send to {student_name}? [y/N]: ").strip().lower()
+        if choice == 'y':
+            try:
+                convos = canvas.create_conversation(
+                    [str(student_id)], message_str, subject=subject_str, force_new=True
+                )
+            except Exception as e:
+                print(f"  -> ERROR sending: {e}\n")
+                logger.warning(f"create_conversation failed for student id={student_id}: {e}")
+                continue
+            convo_id = convos[0].id if convos else None
+            print(f"  -> Sent! (conversation_id={convo_id})\n")
+            sent_messages.append((student_id, student_name, message_str, reason, convo_id))
+        else:
+            print("  -> Skipped.\n")
+
+    n_sent = len(sent_messages)
+    n_skipped = len(messages) - n_sent
+    print(f"\n{n_sent} message(s) sent, {n_skipped} skipped.")
+    logger.info(f"Interactive send: {n_sent} sent, {n_skipped} skipped")
+    return sent_messages
+
+
 class CanvigatorQuiz:
     """A class for one quiz and associated attributes/data."""
 
@@ -566,6 +658,28 @@ class CanvigatorQuiz:
                     quiz_scores[student_id] = score
         return quiz_scores
 
+    def _classifyStudentForQuiz(self, student_id, quiz_scores, points_possible,
+                                subs_by_q_df, events_df, question_info):
+        """Classify a student's state for one quiz. Returns ``(reason, bullets_or_None)``.
+
+        ``reason`` is one of: ``'no attempt'``, ``f'score {score}/{points_possible}'``,
+        ``'page blur'``, or ``'perfect clean'`` (perfect score with no
+        page-blur events on the latest attempt — encourages retake while the
+        quiz is still open).
+        """
+        if student_id not in quiz_scores:
+            return ('no attempt', None)
+
+        score = quiz_scores[student_id]
+        if score < points_possible:
+            bullets = self._buildMissedBulletsForStudent(student_id, subs_by_q_df, question_info)
+            return (f"score {score}/{points_possible}", bullets)
+
+        blur_bullets = self._buildBlurBulletsForStudent(student_id, events_df, question_info)
+        if blur_bullets:
+            return ('page blur', blur_bullets)
+        return ('perfect clean', None)
+
     def sendQuizReminders(self, dry_run=False):
         """Send reminder messages to students who haven't taken the quiz, haven't achieved a perfect score, or had page blur events."""
         quiz_name = self.canvas_quiz.title
@@ -611,6 +725,13 @@ class CanvigatorQuiz:
             "the struggle."
         )
 
+        perfect_clean_template = (
+            "Nice work on earning a perfect score on {quiz_name} and not needing to "
+            "change window focus even once! This quiz isn't due until {due_date} though, "
+            "so it's not a bad idea to take it once more to see if you're still able to "
+            "answer without any external assistance."
+        )
+
         note_str = (
             "\n\nNOTE: This is an auto-generated message that is currently being tested to see "
             "whether it helps encourage students to (re)take a quiz, so please let me know if "
@@ -629,24 +750,24 @@ class CanvigatorQuiz:
             student_name = student['name']
             first_name = student_name.split()[0]
 
-            if student_id not in quiz_scores:
-                reminder = no_attempt_template.format(quiz_name=quiz_name)
-                reason = "no attempt"
-            elif quiz_scores[student_id] < points_possible:
-                score = quiz_scores[student_id]
-                reminder = imperfect_template.format(quiz_name=quiz_name)
-                reason = f"score {score}/{points_possible}"
+            classification = self._classifyStudentForQuiz(
+                student_id, quiz_scores, points_possible, subs_by_q_df, events_df, question_info,
+            )
+            if classification is None:
+                continue
+            reason, bullets = classification
 
-                bullets = self._buildMissedBulletsForStudent(student_id, subs_by_q_df, question_info)
+            if reason == 'no attempt':
+                reminder = no_attempt_template.format(quiz_name=quiz_name)
+            elif reason == 'page blur':
+                reminder = blur_template.format(quiz_name=quiz_name) + (bullets or '')
+            elif reason == 'perfect clean':
+                due_date = format_due_date(getattr(self.canvas_quiz, 'due_at', None))
+                reminder = perfect_clean_template.format(quiz_name=quiz_name, due_date=due_date)
+            else:
+                reminder = imperfect_template.format(quiz_name=quiz_name)
                 if bullets:
                     reminder = reminder + bullets
-            else:
-                # Perfect score — check for page blur events
-                blur_bullets = self._buildBlurBulletsForStudent(student_id, events_df, question_info)
-                if not blur_bullets:
-                    continue
-                reminder = blur_template.format(quiz_name=quiz_name) + blur_bullets
-                reason = "page blur"
 
             message_str = f"Hello {first_name}, {reminder}{note_str}"
             messages.append((student_id, student_name, message_str, reason))
@@ -660,33 +781,13 @@ class CanvigatorQuiz:
                 self._saveReminderManifest(sent_messages, subject_str, dry_run)
 
     def _sendOrPreviewMessages(self, messages, subject_str, quiz_name, points_possible):
-        """Preview the collected messages in dry-run mode and print a summary."""
-        if not messages:
-            print("No reminders to send — all students have perfect scores with no page blur events!")
-            return
+        """Preview the collected messages in dry-run mode (single-quiz path).
 
-        print("\n=== DRY RUN MODE - No messages will be sent on Canvas ===\n")
-
-        print(f"Quiz: {quiz_name} ({points_possible} points possible)")
-        print(f"Reminders to send: {len(messages)}\n")
-
-        for student_id, student_name, message_str, reason in messages:
-            print(f"  [DRY RUN] To: {student_name} (id: {student_id}, {reason})")
-            print(f"            Subject: {subject_str}")
-            print(f"            Message: {message_str}\n")
-
-        n_no_attempt = sum(1 for _, _, _, r in messages if r == "no attempt")
-        n_blur = sum(1 for _, _, _, r in messages if r == "page blur")
-        n_imperfect = len(messages) - n_no_attempt - n_blur
-        summary_parts = []
-        if n_no_attempt:
-            summary_parts.append(f"{n_no_attempt} no-attempt")
-        if n_imperfect:
-            summary_parts.append(f"{n_imperfect} imperfect-score")
-        if n_blur:
-            summary_parts.append(f"{n_blur} page-blur")
-        print(f"\n{len(messages)} reminder(s) would be sent ({', '.join(summary_parts)}).")
-        logger.info(f"Quiz reminders (dry run) would be sent: {len(messages)} for {quiz_name}")
+        Thin wrapper around the module-level ``_sendOrPreviewMessages`` that
+        builds the per-quiz header label.
+        """
+        header_label = f"Quiz: {quiz_name} ({points_possible} points possible)"
+        _sendOrPreviewMessages(messages, subject_str, header_label)
 
     def sendFollowUpQuestions(self, dry_run=False):
         """Send the instructor-selected open-ended follow-up question to students who missed it.
@@ -795,52 +896,13 @@ class CanvigatorQuiz:
                 self._saveFollowUpManifest(sent_messages, selected_qid, question_mode, subject_str, dry_run)
 
     def _interactiveSend(self, messages, subject_str, quiz_name, points_possible):
-        """Interactively prompt the instructor to send or skip each message.
+        """Interactively prompt for send/skip per message (single-quiz path).
 
-        For each student, displays the message preview and asks the instructor
-        to type 'send' or 'skip' (default: skip). Returns the list of messages
-        that were actually sent.
+        Thin wrapper around the module-level ``_interactiveSend`` that builds
+        the per-quiz header label and threads ``self.canvas`` through.
         """
-        if not messages:
-            print("No messages to send!")
-            return []
-
-        print(f"\nQuiz: {quiz_name} ({points_possible} points possible)")
-        print(f"Messages to review: {len(messages)}")
-        print("For each student, enter 'send' to send or press Enter to skip.\n")
-
-        sent_messages = []
-        for i, (student_id, student_name, message_str, reason) in enumerate(messages, 1):
-            print(f"--- Student {i}/{len(messages)} ---")
-            print(f"  To: {student_name} (id: {student_id}, {reason})")
-            print(f"  Subject: {subject_str}")
-            print(f"  Message: {message_str}\n")
-
-            choice = input(f"  Send to {student_name}? [send/SKIP]: ").strip().lower()
-            if choice == 'send':
-                # Capture the conversation ID returned by Canvas so the manifest
-                # can record it. assess-replies fetches each thread directly by ID
-                # rather than scanning the instructor's sent folder by subject —
-                # the sent scope can paginate / filter recent conversations away.
-                try:
-                    convos = self.canvas.create_conversation(
-                        [str(student_id)], message_str, subject=subject_str, force_new=True
-                    )
-                except Exception as e:
-                    print(f"  -> ERROR sending: {e}\n")
-                    logger.warning(f"create_conversation failed for student id={student_id}: {e}")
-                    continue
-                convo_id = convos[0].id if convos else None
-                print(f"  -> Sent! (conversation_id={convo_id})\n")
-                sent_messages.append((student_id, student_name, message_str, reason, convo_id))
-            else:
-                print("  -> Skipped.\n")
-
-        n_sent = len(sent_messages)
-        n_skipped = len(messages) - n_sent
-        print(f"\n{n_sent} message(s) sent, {n_skipped} skipped.")
-        logger.info(f"Interactive send for {quiz_name}: {n_sent} sent, {n_skipped} skipped")
-        return sent_messages
+        header_label = f"Quiz: {quiz_name} ({points_possible} points possible)"
+        return _interactiveSend(self.canvas, messages, subject_str, header_label)
 
     def _findStudentsWhoMissed(self, question_id, subs_by_q_df, question_info):
         """Return a list of student IDs who scored below points_possible on the given question in their latest attempt."""

--- a/canvigator_quiz.py
+++ b/canvigator_quiz.py
@@ -142,28 +142,50 @@ def _render_missed_bullets(missed_rows, question_info):
     return header + "\n".join(lines)
 
 
+def _shortCourseLabel(code):
+    """Return everything in ``code`` before the second hyphen, or before the second space if no hyphens.
+
+    Hyphen split takes priority. Examples:
+      ``CSI-3300-001-12345`` -> ``CSI-3300``
+      ``CS-3120-001 - Spring 2026 - CRN: 32093`` -> ``CS-3120``
+      ``MATH-101`` -> ``MATH-101``
+      ``CS 3120 Spring 2026`` -> ``CS 3120``
+      ``MATH101`` -> ``MATH101``
+    Whitespace around split tokens is trimmed so the result is always tidy.
+    """
+    parts = [p.strip() for p in code.split('-') if p.strip()]
+    if len(parts) >= 2:
+        return '-'.join(parts[:2])
+    parts = [p for p in code.split() if p]
+    if len(parts) >= 2:
+        return ' '.join(parts[:2])
+    return code.strip()
+
+
 def _composeConversationSubject(course_code, quiz_name, suffix, short_code=False):
     """Build a Canvas Conversation subject that includes course identity, quiz, and a per-message suffix.
 
     By default the course code is compacted to ``<prefix>-<number>-<CRN>`` by
     dropping the middle section component when it's present (Canvas codes
     typically look like ``CSI-3300-001-12345``); shorter codes pass through
-    unchanged. When ``short_code=True``, the code is further truncated to the
-    portion before the second hyphen (``<prefix>-<number>``), and codes with
-    zero or one hyphen pass through unchanged — used for follow-up question
-    subjects where the CRN is noise. The suffix is the per-message tail (e.g.
-    ``"Q3 Follow-Up"`` or ``"Reminder"``). The richer subject lets
-    students/instructors group conversations across classes, quizzes, and
-    questions; threads themselves are still tracked internally by
-    ``conversation_id``, so subject changes are safe.
+    unchanged. When ``short_code=True``, the code is further truncated by
+    ``_shortCourseLabel`` to the portion before the second hyphen (or before
+    the second space if the code has no hyphens) — used for reminders and
+    follow-up question subjects where the CRN/section/term suffix is noise.
+    The suffix is the per-message tail (e.g. ``"Q3 Follow-Up"`` or
+    ``"Reminder"``). The richer subject lets students/instructors group
+    conversations across classes, quizzes, and questions; threads themselves
+    are still tracked internally by ``conversation_id``, so subject changes
+    are safe.
     """
     code = str(course_code).strip() if course_code else ''
-    code_parts = [p for p in code.split('-') if p]
     if short_code:
-        code_parts = code_parts[:2]
-    elif len(code_parts) == 4:
-        code_parts = [code_parts[0], code_parts[1], code_parts[3]]
-    course_label = '-'.join(code_parts) if code_parts else 'Course'
+        course_label = _shortCourseLabel(code) or 'Course'
+    else:
+        code_parts = [p for p in code.split('-') if p]
+        if len(code_parts) == 4:
+            code_parts = [code_parts[0], code_parts[1], code_parts[3]]
+        course_label = '-'.join(code_parts) if code_parts else 'Course'
     parts = [course_label, str(quiz_name).strip()]
     if suffix and str(suffix).strip():
         parts.append(str(suffix).strip())
@@ -749,6 +771,7 @@ class CanvigatorQuiz:
             self.canvas_course.canvas_course.course_code,
             quiz_name,
             "Reminder",
+            short_code=True,
         )
         messages = []
 

--- a/canvigator_quiz.py
+++ b/canvigator_quiz.py
@@ -507,10 +507,17 @@ class CanvigatorQuiz:
         quiz_id = self.canvas_quiz.id
         assignment_id = getattr(self.canvas_quiz, 'assignment_id', None)
 
-        fields = ['position', 'question_name', 'question_type', 'question_text', 'points_possible']
+        # Canvas's per-question `position` field is set at creation time and is not
+        # reliably updated when questions are reordered or removed, so we ignore it
+        # and number questions 1..N in the order Canvas returns them — which is the
+        # order students see them. This `position` then flows through to the
+        # `*_questions_w_tags_*.csv`, the `*_open_ended_*.csv`, and the
+        # student-facing "Q{position}" bullets in send-quiz-reminder.
+        fields = ['question_name', 'question_type', 'question_text', 'points_possible']
         rows = []
-        for q in self.quiz_questions:
+        for idx, q in enumerate(self.quiz_questions, start=1):
             row = {'quiz_id': quiz_id, 'assignment_id': assignment_id, 'question_id': getattr(q, 'id', None)}
+            row['position'] = idx
             row.update({f: getattr(q, f, None) for f in fields})
             row['answers'] = json.dumps(getattr(q, 'answers', []))
             rows.append(row)

--- a/canvigator_utils.py
+++ b/canvigator_utils.py
@@ -13,6 +13,17 @@ def today_str():
     return datetime.today().strftime('%Y%m%d')
 
 
+def format_due_date(due_at):
+    """Format a Canvas due_at ISO timestamp as YYYY-MM-DD; return '?' on failure."""
+    if not due_at:
+        return '?'
+    try:
+        dt = datetime.fromisoformat(str(due_at).replace('Z', '+00:00'))
+    except (TypeError, ValueError, AttributeError):
+        return '?'
+    return dt.strftime('%Y-%m-%d')
+
+
 SPINNER_FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 
 

--- a/test_canvigator.py
+++ b/test_canvigator.py
@@ -2098,3 +2098,201 @@ class TestCollectLockedExamples:
         out = self._stub()._collectLockedExamples(df, 42)
         passes = [e for e in out if e['result'] == 'pass']
         assert len(passes) == cap
+
+
+# ---------------------------------------------------------------------------
+# Multi-quiz reminder tests (--all path for send-quiz-reminder)
+# ---------------------------------------------------------------------------
+
+class TestClassifyStudentForQuiz:
+    """Tests for CanvigatorQuiz._classifyStudentForQuiz."""
+
+    def _quiz(self):
+        """Return a CanvigatorQuiz instance bypassing __init__ for direct method tests."""
+        from canvigator_quiz import CanvigatorQuiz
+        return CanvigatorQuiz.__new__(CanvigatorQuiz)
+
+    def test_no_attempt(self):
+        """Student missing from quiz_scores → 'no attempt' with no bullets."""
+        result = self._quiz()._classifyStudentForQuiz(
+            student_id=99, quiz_scores={}, points_possible=10.0,
+            subs_by_q_df=None, events_df=None, question_info={},
+        )
+        assert result == ('no attempt', None)
+
+    def test_imperfect_score_with_bullets(self, monkeypatch):
+        """Student with score < points_possible → 'score x/y' with bullet section."""
+        quiz = self._quiz()
+        monkeypatch.setattr(quiz, '_buildMissedBulletsForStudent',
+                            lambda sid, df, qi: '\n• Q1: keywords (5/10 pts)')
+        result = quiz._classifyStudentForQuiz(
+            student_id=42, quiz_scores={42: 7}, points_possible=10,
+            subs_by_q_df=None, events_df=None, question_info={},
+        )
+        assert result[0] == 'score 7/10'
+        assert 'Q1: keywords' in result[1]
+
+    def test_perfect_with_blur(self, monkeypatch):
+        """Student with perfect score and blur events → 'page blur' with bullets."""
+        quiz = self._quiz()
+        monkeypatch.setattr(quiz, '_buildBlurBulletsForStudent',
+                            lambda sid, df, qi: '\n• Q2: stuff')
+        result = quiz._classifyStudentForQuiz(
+            student_id=42, quiz_scores={42: 10}, points_possible=10,
+            subs_by_q_df=None, events_df=None, question_info={},
+        )
+        assert result[0] == 'page blur'
+        assert 'Q2: stuff' in result[1]
+
+    def test_perfect_no_blur_returns_perfect_clean(self, monkeypatch):
+        """Perfect score with no blur events → 'perfect clean' (encourage retake)."""
+        quiz = self._quiz()
+        monkeypatch.setattr(quiz, '_buildBlurBulletsForStudent', lambda sid, df, qi: None)
+        result = quiz._classifyStudentForQuiz(
+            student_id=42, quiz_scores={42: 10}, points_possible=10,
+            subs_by_q_df=None, events_df=None, question_info={},
+        )
+        assert result == ('perfect clean', None)
+
+
+class TestComposeMultiQuizReminder:
+    """Tests for canvigator_course._composeMultiQuizReminder."""
+
+    def test_orders_sections_in_input_order(self):
+        """Sections are emitted in the order provided in state_list."""
+        from canvigator_course import _composeMultiQuizReminder
+        state_list = [
+            {'quiz_name': 'Quiz A', 'due_at': '2026-05-01T12:00:00Z',
+             'points_possible': 10, 'reason': 'no attempt', 'bullets': None},
+            {'quiz_name': 'Quiz B', 'due_at': '2026-05-05T12:00:00Z',
+             'points_possible': 10, 'reason': 'score 7/10',
+             'bullets': '\n• Q1: foo (5/10 pts)'},
+            {'quiz_name': 'Quiz C', 'due_at': '2026-05-10T12:00:00Z',
+             'points_possible': 10, 'reason': 'page blur', 'bullets': '\n• Q2: bar'},
+        ]
+        body = _composeMultiQuizReminder('Alex', state_list)
+
+        # Greeting and structure
+        assert body.startswith('Hello Alex,')
+
+        # Order check: A appears before B which appears before C
+        i_a = body.index('Quiz A')
+        i_b = body.index('Quiz B')
+        i_c = body.index('Quiz C')
+        assert i_a < i_b < i_c
+
+        # Per-section formatting
+        assert 'Quiz A (due 2026-05-01) — not yet attempted' in body
+        assert 'Quiz B (due 2026-05-05) — score 7/10' in body
+        assert '• Q1: foo (5/10 pts)' in body
+        assert 'Quiz C (due 2026-05-10) — perfect score' in body
+        assert '• Q2: bar' in body
+
+        # NOTE disclaimer present
+        assert 'auto-generated message' in body
+
+    def test_handles_missing_due_at(self):
+        """A quiz with no due_at falls back to '?' in the section header."""
+        from canvigator_course import _composeMultiQuizReminder
+        body = _composeMultiQuizReminder('Sam', [
+            {'quiz_name': 'Q', 'due_at': None,
+             'points_possible': 5, 'reason': 'no attempt', 'bullets': None},
+        ])
+        assert 'Q (due ?)' in body
+
+    def test_skips_bullets_when_none(self):
+        """Section with bullets=None renders just the header, no nested bullet block."""
+        from canvigator_course import _composeMultiQuizReminder
+        body = _composeMultiQuizReminder('Sam', [
+            {'quiz_name': 'Q1', 'due_at': '2026-05-01T12:00:00Z',
+             'points_possible': 5, 'reason': 'no attempt', 'bullets': None},
+        ])
+        assert 'Q1 (due 2026-05-01) — not yet attempted' in body
+        # Only the section header bullet appears — no nested bullets below it.
+        assert body.count('•') == 1
+
+    def test_perfect_clean_section(self):
+        """A 'perfect clean' state renders a retake-encouraging section header."""
+        from canvigator_course import _composeMultiQuizReminder
+        body = _composeMultiQuizReminder('Sam', [
+            {'quiz_name': 'Q5', 'due_at': '2026-05-15T12:00:00Z',
+             'points_possible': 10, 'reason': 'perfect clean', 'bullets': None},
+        ])
+        assert 'Q5 (due 2026-05-15) — nice work, perfect score with no window changes' in body
+        assert 'consider retaking' in body
+
+
+class TestSendAllQuizRemindersFiltering:
+    """Tests for sendAllQuizReminders quiz filtering and missing-CSV skip."""
+
+    def _make_course_stub(self, quizzes, students):
+        """Build a CanvigatorCourse instance bypassing __init__ for direct method tests."""
+        from canvigator_course import CanvigatorCourse
+
+        class _CanvasCourse:
+            def __init__(self, quizzes):
+                self._quizzes = quizzes
+                self.course_code = 'CSI-3300-001-12345'
+
+            def get_quizzes(self):
+                return self._quizzes
+
+        course = CanvigatorCourse.__new__(CanvigatorCourse)
+        course.canvas = None
+        course.canvas_course = _CanvasCourse(quizzes)
+        course.config = None
+        course.students = students
+        course.verbose = False
+        return course
+
+    def test_filters_to_eligible_quizzes_and_skips_when_empty(self, capsys, monkeypatch):
+        """When no quiz passes is_quiz_open_for_reminder, the method returns early."""
+        from datetime import timezone as _tz
+        # Past-due quiz only
+        quizzes = [_StubQuiz(published=True, due_at='2026-01-01T12:00:00Z')]
+        course = self._make_course_stub(quizzes, students=[{'id': 1, 'name': 'Alice A'}])
+
+        # Freeze "now" so the past quiz remains past
+        from canvigator_utils import is_quiz_open_for_reminder as orig
+        ref_now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=_tz.utc)
+        monkeypatch.setattr('canvigator_course.cu.is_quiz_open_for_reminder',
+                            lambda q: orig(q, now=ref_now))
+
+        course.sendAllQuizReminders(dry_run=True)
+        captured = capsys.readouterr().out
+        assert 'No published quizzes with a future due date' in captured
+
+    def test_skips_quizzes_missing_tagged_csv(self, capsys, monkeypatch, caplog):
+        """A quiz whose _loadQuestionInfo raises FileNotFoundError is skipped with a warning."""
+        import logging as _logging
+        from datetime import timezone as _tz
+        # One eligible quiz; the only quiz lacks the tagged CSV
+        quizzes = [_StubQuiz(published=True, due_at='2026-12-31T12:00:00Z')]
+        # give it required attrs the constructor will need
+        quizzes[0].id = 999
+        quizzes[0].title = 'Quiz Z'
+        quizzes[0].points_possible = 10
+        course = self._make_course_stub(quizzes, students=[{'id': 1, 'name': 'Alice A'}])
+
+        from canvigator_utils import is_quiz_open_for_reminder as orig
+        ref_now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=_tz.utc)
+        monkeypatch.setattr('canvigator_course.cu.is_quiz_open_for_reminder',
+                            lambda q: orig(q, now=ref_now))
+
+        # Stub the CanvigatorQuiz constructor to return an object whose
+        # _loadQuestionInfo raises FileNotFoundError.
+        class _FakeQuiz:
+            def __init__(self, *a, **kw):
+                pass
+
+            def _loadQuestionInfo(self):
+                raise FileNotFoundError('No *_questions_w_tags_*.csv found for quiz')
+        monkeypatch.setattr('canvigator_course.cq.CanvigatorQuiz', _FakeQuiz)
+
+        with caplog.at_level(_logging.WARNING, logger='canvigator_course'):
+            course.sendAllQuizReminders(dry_run=True)
+        captured = capsys.readouterr().out
+        assert "Skipping 'Quiz Z'" in captured
+        assert any("Skipping 'Quiz Z'" in r.message for r in caplog.records)
+        # No reminder-worthy state, so we hit the "all caught up" branch
+        assert 'All students are caught up' in captured

--- a/test_canvigator.py
+++ b/test_canvigator.py
@@ -2100,6 +2100,63 @@ class TestCollectLockedExamples:
         assert len(passes) == cap
 
 
+class TestGetQuizQuestionsPosition:
+    """Tests that getQuizQuestions enumerates `position` as 1..N regardless of Canvas's stale `position` field."""
+
+    def _stub_quiz(self, canvas_questions, tmp_path):
+        """Build a CanvigatorQuiz instance bypassing __init__ for direct method tests."""
+        from canvigator_quiz import CanvigatorQuiz
+
+        class _Config:
+            def __init__(self, data_path):
+                self.data_path = data_path
+                self.quiz_prefix = 'quiz'
+
+        class _CanvasQuiz:
+            id = 999
+            assignment_id = 12345
+
+        quiz = CanvigatorQuiz.__new__(CanvigatorQuiz)
+        quiz.canvas_quiz = _CanvasQuiz()
+        quiz.config = _Config(tmp_path)
+        quiz.quiz_questions = canvas_questions
+        return quiz
+
+    def _question_stub(self, qid, position, name, qtype='multiple_choice_question', text='', pp=1.0):
+        """Build a minimal stand-in for a canvasapi QuizQuestion object."""
+        class _Q:
+            pass
+        q = _Q()
+        q.id = qid
+        q.position = position
+        q.question_name = name
+        q.question_type = qtype
+        q.question_text = text
+        q.points_possible = pp
+        q.answers = []
+        return q
+
+    def test_position_is_one_based_enumeration(self, tmp_path):
+        """`position` reflects iteration order, not Canvas's stale per-question position field."""
+        # Canvas reports stale positions: out-of-order values, gaps from removed questions
+        canvas_questions = [
+            self._question_stub(101, position=7, name='Q one'),     # stale 7
+            self._question_stub(102, position=2, name='Q two'),     # stale 2
+            self._question_stub(103, position=42, name='Q three'),  # stale 42 (gap)
+        ]
+        quiz = self._stub_quiz(canvas_questions, tmp_path)
+        quiz.getQuizQuestions(tag=False)
+
+        out_files = list(tmp_path.glob('quiz999_questions_*.csv'))
+        assert len(out_files) == 1
+        df = pd.read_csv(out_files[0])
+
+        # Position is 1..N in iteration order, ignoring Canvas's reported values
+        assert list(df['position']) == [1, 2, 3]
+        assert list(df['question_id']) == [101, 102, 103]
+        assert list(df['question_name']) == ['Q one', 'Q two', 'Q three']
+
+
 # ---------------------------------------------------------------------------
 # Multi-quiz reminder tests (--all path for send-quiz-reminder)
 # ---------------------------------------------------------------------------

--- a/test_canvigator.py
+++ b/test_canvigator.py
@@ -1300,9 +1300,25 @@ class TestComposeConversationSubject:
         assert out == 'MATH-101 - Quiz 1 - Q1 Follow-Up'
 
     def test_short_code_preserves_hyphenless_code(self):
-        """A code with no hyphens passes through entirely."""
+        """A code with no hyphens and no spaces passes through entirely."""
         out = self._call('MATH101', 'Quiz 1', 'Q1 Follow-Up', short_code=True)
         assert out == 'MATH101 - Quiz 1 - Q1 Follow-Up'
+
+    def test_short_code_truncates_long_padded_code(self):
+        """A long course_code with embedded ' - ' separators truncates to '<prefix>-<number>'."""
+        # Models a Canvas course_code where extra metadata follows the section/CRN
+        out = self._call('CS-3120-001 - Spring 2026 - CRN: 32093', 'Quiz 8', 'Reminder', short_code=True)
+        assert out == 'CS-3120 - Quiz 8 - Reminder'
+
+    def test_short_code_falls_back_to_space_split(self):
+        """When the code has no hyphens, the second space is the truncation point."""
+        out = self._call('CS 3120 Spring 2026 CRN 32093', 'Quiz 1', 'Reminder', short_code=True)
+        assert out == 'CS 3120 - Quiz 1 - Reminder'
+
+    def test_short_code_single_token_is_unchanged(self):
+        """A single token (no hyphens, no spaces) is preserved verbatim."""
+        out = self._call('STANDALONE', 'Quiz 1', 'Reminder', short_code=True)
+        assert out == 'STANDALONE - Quiz 1 - Reminder'
 
 
 # ---------------------------------------------------------------------------

--- a/test_canvigator.py
+++ b/test_canvigator.py
@@ -2221,6 +2221,51 @@ class TestComposeMultiQuizReminder:
         assert 'Q5 (due 2026-05-15) — nice work, perfect score with no window changes' in body
         assert 'consider retaking' in body
 
+    def test_single_quiz_keeps_top_level_bullets(self):
+        """With only one quiz, bullets stay at top level (preamble preserved, no indent)."""
+        from canvigator_course import _composeMultiQuizReminder
+        bullets_block = (
+            "\n\nThe questions that you missed on this most recent attempt covered "
+            "the concepts/topics:\n• Q1: foo (5/10 pts)\n• Q3: bar (2/10 pts)"
+        )
+        body = _composeMultiQuizReminder('Sam', [
+            {'quiz_name': 'Quiz Solo', 'due_at': '2026-05-01T12:00:00Z',
+             'points_possible': 10, 'reason': 'score 7/10', 'bullets': bullets_block},
+        ])
+        # Preamble is preserved
+        assert 'covered the concepts/topics' in body
+        # Bullets are NOT indented (no '  •' anywhere)
+        assert '\n  •' not in body
+        # Top-level bullets present
+        assert '\n• Q1: foo (5/10 pts)' in body
+
+    def test_multi_quiz_indents_bullets_as_sub_bullets(self):
+        """With 2+ quizzes, per-question bullets become 2-space-indented sub-bullets and the preamble is dropped."""
+        from canvigator_course import _composeMultiQuizReminder
+        missed_block = (
+            "\n\nThe questions that you missed on this most recent attempt covered "
+            "the concepts/topics:\n• Q1: foo (5/10 pts)\n• Q3: bar (2/10 pts)"
+        )
+        blur_block = (
+            "\n\nThe questions that you changed window focus on covered the concepts/topics:"
+            "\n• Q2: baz"
+        )
+        body = _composeMultiQuizReminder('Sam', [
+            {'quiz_name': 'Quiz A', 'due_at': '2026-05-01T12:00:00Z',
+             'points_possible': 10, 'reason': 'score 7/10', 'bullets': missed_block},
+            {'quiz_name': 'Quiz B', 'due_at': '2026-05-05T12:00:00Z',
+             'points_possible': 10, 'reason': 'page blur', 'bullets': blur_block},
+        ])
+        # Quiz names render as top-level bullets
+        assert '\n• Quiz A (due 2026-05-01) — score 7/10' in body
+        assert '\n• Quiz B (due 2026-05-05) — perfect score' in body
+        # Per-question bullets are 2-space-indented sub-bullets
+        assert '\n  • Q1: foo (5/10 pts)' in body
+        assert '\n  • Q3: bar (2/10 pts)' in body
+        assert '\n  • Q2: baz' in body
+        # Preamble dropped in nested mode
+        assert 'covered the concepts/topics' not in body
+
 
 class TestSendAllQuizRemindersFiltering:
     """Tests for sendAllQuizReminders quiz filtering and missing-CSV skip."""


### PR DESCRIPTION
## Summary

- Add a `--all`/`-a` option to `send-quiz-reminder` that iterates every published, future-due quiz and sends each student **one consolidated Canvas message** covering every quiz they're behind on. A new `'perfect clean'` reason (perfect score with no page-blur events) joins the existing `'no attempt'` / `'score x/y'` / `'page blur'` reasons, encouraging a retake while the quiz is still open.
- Multi-quiz messages render quiz names as top-level bullets and per-question lines as 2-space-indented sub-bullets; single-quiz messages keep the flat format.
- Shorten reminder subjects to `<prefix>-<number> - <quiz name> - Reminder` (e.g. `CS-3120 - Quiz 8 - Reminder`) for both single-quiz and `--all` paths, with a fallback that splits on spaces when the course code has no hyphens.
- Fix `position` numbering in `get-quiz-questions` so `Q{position}` shown to students reflects the order Canvas serves the questions (1..N enumeration), not the stale `position` field Canvas reports for reordered/removed questions. Propagates through `*_questions_w_tags_*.csv` and `*_open_ended_*.csv` into `send-quiz-reminder` and `send-follow-up-question`.
- Strengthen the LLM prompts in `generate-follow-up-questions` so the generated open-ended questions are fully stand-alone and never reference the original quiz question.
- Tighten the per-message interactive send prompt from `[send/SKIP]` to `[y/N]` — N is the default; only `y` + Enter sends.

A single course-level manifest `course_reminder_sent[_dryrun]_YYYYMMDD.csv` is written for `--all` runs (pipe-delimited `quiz_ids`/`quiz_names`/`reasons`), rather than per-quiz manifests.

## Test plan

- [x] `python -m pytest test_canvigator.py -v` — 194 tests pass (includes new tests for `_classifyStudentForQuiz` branches, multi-quiz rendering / sub-bullet nesting, `sendAllQuizReminders` filtering and missing-tags-CSV skip, `getQuizQuestions` position enumeration, and short-code subject truncation).
- [x] Both flake8 commands pass (syntax + complexity/length).
- [ ] Single-quiz dry-run regression — `python canvigator.py --crn <CRN> --dry-run send-quiz-reminder`, pick a quiz, confirm subject is now `<prefix>-<number> - <quiz> - Reminder` and message rendering is unchanged for the four reasons.
- [x] `--all` dry-run on a real course — `python canvigator.py --crn <CRN> --all --dry-run send-quiz-reminder`. Confirm: quizzes processed in due-date order, at least one student gets multiple sections, sub-bullets are 2-space indented, quizzes lacking `*_questions_w_tags_*.csv` are skipped with a warning, `course_reminder_sent_dryrun_*.csv` is written.
- [x] Live `--all` send to a small batch (use the new `[y/N]` per-student prompt to send to one or two students), confirm `conversation_id`s captured in the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)