### PR TITLE
Media recording check-ins: create, transcribe, grade, and analyze

### DIFF
--- a/canvigator.py
+++ b/canvigator.py
@@ -19,6 +19,10 @@ task_groups = [
         ('assess-replies', 'Fetch the latest student follow-up replies from Canvas and assess them with a local LLM'),
         ('send-follow-up-assessments', 'Send instructor-curated assessment feedback back to students (requires assess-replies)'),
     ]),
+    ('Media Recording Check-Ins', [
+        ('create-media-recording-assignment', 'Create a Canvas assignment that accepts only media_recording submissions'),
+        ('get-media-recordings', 'Fetch + transcribe student audio submissions for a media-recording assignment (use --grade to award full credit)'),
+    ]),
     ('Miscellaneous tasks', [
         ('create-quiz', 'Create an unpublished placeholder quiz on Canvas'),
         ('export-anon-data', 'Export anonymized course data (no Canvas API needed)'),
@@ -39,12 +43,14 @@ def print_help():
     """Print usage information with grouped task descriptions."""
     print("Usage: canvigator.py [OPTIONS] <task>\n")
     print("Options (short and long forms are interchangeable):")
-    print("  -d, --dry-run                Preview changes without modifying Canvas (applies to bonus, reminder, follow-up, feedback, delete-old-conversations)")
+    print("  -d, --dry-run                Preview changes without modifying Canvas (applies to bonus, reminder, follow-up,")
+    print("                               feedback, delete-old-conversations, get-media-recordings --grade)")
     print("  -t, --tag                    Use a cloud LLM via Ollama to tag questions (get-quiz-questions only)")
     print("  -a, --all                    Run across every quiz in the course (get-quiz-questions, get-quiz-submission-events, send-quiz-reminder)")
     print("  -c, --crn <CRN>              Select course by CRN (last 5 digits of course code)")
     print("  -m, --months <N>             Age threshold in months for delete-old-conversations (default: 6)")
     print("  -w, --reply-window-days <N>  Days to accept replies after follow-up sent (default: 5, assess-replies only)")
+    print("  -g, --grade                  Auto-award points_possible to every submitter (get-media-recordings only)")
     max_name = max(len(t) for t in tasks)
     for header, items in task_groups:
         print(f"\n{header}")
@@ -55,6 +61,18 @@ def print_help():
     print("    1. Classifies each question as 'explain' (oral) or 'draw' (visual)")
     print("    2. Generates a mode-appropriate open-ended question for instructor review")
     print("  Output CSV includes a question_mode column so the instructor can override choices.")
+
+
+def _run_assignment_task(task, course, canvas, canv_config, dry_run, grade_flag):
+    """Dispatch the two media-recording-assignment tasks."""
+    import canvigator_assignment as ca
+    if task == 'create-media-recording-assignment':
+        ca.createMediaRecordingAssignment(course)
+        return
+    assignment_choice = ca._selectMediaRecordingAssignment(course)
+    print(f"\nSelected assignment: {assignment_choice.name}")
+    cassign = ca.CanvigatorAssignment(canvas, course, assignment_choice, canv_config)
+    cassign.getMediaRecordings(grade=grade_flag, dry_run=dry_run)
 
 
 def _run_quiz_task(task, quiz, dry_run, tag, reply_window_days):
@@ -99,6 +117,7 @@ _SHORT_TO_LONG = {
     '-c': '--crn',
     '-m': '--months',
     '-w': '--reply-window-days',
+    '-g': '--grade',
 }
 args = [_SHORT_TO_LONG.get(a, a) for a in sys.argv[1:]]
 
@@ -113,6 +132,10 @@ if tag:
 all_quizzes_flag = '--all' in args
 if all_quizzes_flag:
     args.remove('--all')
+
+grade_flag = '--grade' in args
+if grade_flag:
+    args.remove('--grade')
 
 crn = None
 if '--crn' in args:
@@ -277,6 +300,9 @@ elif task == 'send-quiz-reminder' and all_quizzes_flag:
 
 elif task == 'create-quiz':
     course.createQuiz()
+
+elif task in ('create-media-recording-assignment', 'get-media-recordings'):
+    _run_assignment_task(task, course, canvas, canv_config, dry_run, grade_flag)
 
 elif task == 'get-gradebook':
     course.exportGradebook(canv_config.data_path)

--- a/canvigator.py
+++ b/canvigator.py
@@ -22,6 +22,7 @@ task_groups = [
     ('Media Recording Check-Ins', [
         ('create-media-recording-assignment', 'Create a Canvas assignment that accepts only media_recording submissions'),
         ('get-media-recordings', 'Fetch + transcribe student audio submissions; review and grade each interactively (or use --auto-grade)'),
+        ('analyze-media-recordings', 'Analyze transcripts: tag-grounded counts + LLM-extracted themes (requires get-media-recordings + a quiz tags CSV)'),
     ]),
     ('Miscellaneous tasks', [
         ('create-quiz', 'Create an unpublished placeholder quiz on Canvas'),
@@ -64,7 +65,7 @@ def print_help():
 
 
 def _run_assignment_task(task, course, canvas, canv_config, dry_run, auto_grade_flag):
-    """Dispatch the two media-recording-assignment tasks."""
+    """Dispatch the media-recording-assignment tasks."""
     import canvigator_assignment as ca
     if task == 'create-media-recording-assignment':
         ca.createMediaRecordingAssignment(course)
@@ -72,7 +73,10 @@ def _run_assignment_task(task, course, canvas, canv_config, dry_run, auto_grade_
     assignment_choice = ca._selectMediaRecordingAssignment(course)
     print(f"\nSelected assignment: {assignment_choice.name}")
     cassign = ca.CanvigatorAssignment(canvas, course, assignment_choice, canv_config)
-    cassign.getMediaRecordings(auto_grade=auto_grade_flag, dry_run=dry_run)
+    if task == 'analyze-media-recordings':
+        cassign.analyzeRecordings()
+    else:
+        cassign.getMediaRecordings(auto_grade=auto_grade_flag, dry_run=dry_run)
 
 
 def _run_quiz_task(task, quiz, dry_run, tag, reply_window_days):
@@ -301,7 +305,7 @@ elif task == 'send-quiz-reminder' and all_quizzes_flag:
 elif task == 'create-quiz':
     course.createQuiz()
 
-elif task in ('create-media-recording-assignment', 'get-media-recordings'):
+elif task in ('create-media-recording-assignment', 'get-media-recordings', 'analyze-media-recordings'):
     _run_assignment_task(task, course, canvas, canv_config, dry_run, auto_grade_flag)
 
 elif task == 'get-gradebook':

--- a/canvigator.py
+++ b/canvigator.py
@@ -21,7 +21,7 @@ task_groups = [
     ]),
     ('Media Recording Check-Ins', [
         ('create-media-recording-assignment', 'Create a Canvas assignment that accepts only media_recording submissions'),
-        ('get-media-recordings', 'Fetch + transcribe student audio submissions for a media-recording assignment (use --grade to award full credit)'),
+        ('get-media-recordings', 'Fetch + transcribe student audio submissions; review and grade each interactively (or use --auto-grade)'),
     ]),
     ('Miscellaneous tasks', [
         ('create-quiz', 'Create an unpublished placeholder quiz on Canvas'),
@@ -44,13 +44,13 @@ def print_help():
     print("Usage: canvigator.py [OPTIONS] <task>\n")
     print("Options (short and long forms are interchangeable):")
     print("  -d, --dry-run                Preview changes without modifying Canvas (applies to bonus, reminder, follow-up,")
-    print("                               feedback, delete-old-conversations, get-media-recordings --grade)")
+    print("                               feedback, delete-old-conversations, get-media-recordings — CSV is still written)")
     print("  -t, --tag                    Use a cloud LLM via Ollama to tag questions (get-quiz-questions only)")
     print("  -a, --all                    Run across every quiz in the course (get-quiz-questions, get-quiz-submission-events, send-quiz-reminder)")
     print("  -c, --crn <CRN>              Select course by CRN (last 5 digits of course code)")
     print("  -m, --months <N>             Age threshold in months for delete-old-conversations (default: 6)")
     print("  -w, --reply-window-days <N>  Days to accept replies after follow-up sent (default: 5, assess-replies only)")
-    print("  -g, --grade                  Auto-award points_possible to every submitter (get-media-recordings only)")
+    print("  -g, --auto-grade             Skip per-student review prompt and auto-award points_possible (get-media-recordings only)")
     max_name = max(len(t) for t in tasks)
     for header, items in task_groups:
         print(f"\n{header}")
@@ -63,7 +63,7 @@ def print_help():
     print("  Output CSV includes a question_mode column so the instructor can override choices.")
 
 
-def _run_assignment_task(task, course, canvas, canv_config, dry_run, grade_flag):
+def _run_assignment_task(task, course, canvas, canv_config, dry_run, auto_grade_flag):
     """Dispatch the two media-recording-assignment tasks."""
     import canvigator_assignment as ca
     if task == 'create-media-recording-assignment':
@@ -72,7 +72,7 @@ def _run_assignment_task(task, course, canvas, canv_config, dry_run, grade_flag)
     assignment_choice = ca._selectMediaRecordingAssignment(course)
     print(f"\nSelected assignment: {assignment_choice.name}")
     cassign = ca.CanvigatorAssignment(canvas, course, assignment_choice, canv_config)
-    cassign.getMediaRecordings(grade=grade_flag, dry_run=dry_run)
+    cassign.getMediaRecordings(auto_grade=auto_grade_flag, dry_run=dry_run)
 
 
 def _run_quiz_task(task, quiz, dry_run, tag, reply_window_days):
@@ -117,7 +117,7 @@ _SHORT_TO_LONG = {
     '-c': '--crn',
     '-m': '--months',
     '-w': '--reply-window-days',
-    '-g': '--grade',
+    '-g': '--auto-grade',
 }
 args = [_SHORT_TO_LONG.get(a, a) for a in sys.argv[1:]]
 
@@ -133,9 +133,9 @@ all_quizzes_flag = '--all' in args
 if all_quizzes_flag:
     args.remove('--all')
 
-grade_flag = '--grade' in args
-if grade_flag:
-    args.remove('--grade')
+auto_grade_flag = '--auto-grade' in args
+if auto_grade_flag:
+    args.remove('--auto-grade')
 
 crn = None
 if '--crn' in args:
@@ -302,7 +302,7 @@ elif task == 'create-quiz':
     course.createQuiz()
 
 elif task in ('create-media-recording-assignment', 'get-media-recordings'):
-    _run_assignment_task(task, course, canvas, canv_config, dry_run, grade_flag)
+    _run_assignment_task(task, course, canvas, canv_config, dry_run, auto_grade_flag)
 
 elif task == 'get-gradebook':
     course.exportGradebook(canv_config.data_path)

--- a/canvigator_assignment.py
+++ b/canvigator_assignment.py
@@ -1,0 +1,272 @@
+"""Media-recording check-in assignments.
+
+Lightweight participation flow built on Canvas Assignments restricted to
+``media_recording`` submissions. The instructor posts a single open-ended
+prompt ("explain a topic", "what did you struggle with"), students upload
+an audio recording from Canvas, and ``get-media-recordings`` fetches every
+submission, downloads the audio, and transcribes it locally so the
+instructor can scan a CSV instead of listening to N recordings.
+"""
+import logging
+import os
+from datetime import datetime, timezone
+
+import pandas as pd
+import requests
+
+from canvigator_utils import today_str, selectFromList
+from canvigator_llm import transcribe_audio, _make_client, DEFAULT_AUDIO_MODEL
+
+logger = logging.getLogger(__name__)
+
+
+def _isMediaRecordingAssignment(assignment):
+    """Return True if the assignment accepts only media_recording submissions."""
+    types = getattr(assignment, 'submission_types', None)
+    return list(types or []) == ['media_recording']
+
+
+def _selectMediaRecordingAssignment(course):
+    """List media-recording assignments in the course and prompt the instructor to pick one."""
+    candidates = [a for a in course.canvas_course.get_assignments() if _isMediaRecordingAssignment(a)]
+    if not candidates:
+        raise ValueError(
+            "No media-recording assignments found in this course. "
+            "Run 'create-media-recording-assignment' first."
+        )
+    return selectFromList(candidates, "assignment")
+
+
+def _promptInt(prompt, default):
+    """Prompt for a non-negative integer, returning ``default`` on empty input."""
+    raw = input(f"{prompt} [{default}]: ").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+        if value < 0:
+            raise ValueError
+        return value
+    except ValueError:
+        print(f"  Invalid integer; using default ({default}).")
+        return default
+
+
+def _promptYesNo(prompt, default=False):
+    """Prompt for y/n; returns ``default`` on empty input."""
+    suffix = "y/N" if not default else "Y/n"
+    raw = input(f"{prompt} [{suffix}]: ").strip().lower()
+    if not raw:
+        return default
+    return raw in ('y', 'yes')
+
+
+def createMediaRecordingAssignment(course):
+    """Interactively create a Canvas assignment that accepts only media_recording submissions.
+
+    Mirrors the interactive style of ``CanvigatorCourse.createQuiz``. The instructor
+    supplies a title, a prompt body (becomes the assignment description), point value,
+    and optional due date; the assignment is created unpublished by default so the
+    instructor can review before exposing it to students.
+    """
+    title = input("Enter assignment title: ").strip()
+    if not title:
+        print("Assignment title cannot be empty.")
+        return
+
+    print("\nEnter the prompt students will see (single line). Examples:")
+    print("  'In 30 seconds, explain what we discussed about hash tables today.'")
+    print("  'What did you struggle with this week?'")
+    body = input("Prompt: ").strip()
+    if not body:
+        print("Prompt cannot be empty.")
+        return
+    description_html = f"<p>{body}</p>"
+
+    points_possible = _promptInt("Points possible", 1)
+
+    due_at_raw = input("Due at (ISO 8601, e.g. 2026-05-08T23:59:00; press Enter for none): ").strip()
+    due_at = None
+    if due_at_raw:
+        try:
+            datetime.fromisoformat(due_at_raw.replace('Z', '+00:00'))
+            due_at = due_at_raw
+        except ValueError:
+            print(f"  Could not parse '{due_at_raw}' as ISO 8601 — leaving due_at unset.")
+
+    publish_now = _promptYesNo("Publish immediately?", default=False)
+
+    payload = {
+        'name': title,
+        'description': description_html,
+        'submission_types': ['media_recording'],
+        'points_possible': points_possible,
+        'published': publish_now,
+    }
+    if due_at:
+        payload['due_at'] = due_at
+
+    assignment = course.canvas_course.create_assignment(payload)
+    state = "published" if publish_now else "unpublished"
+    print(f"\nCreated assignment: '{assignment.name}' (id={assignment.id}, {state})")
+    if hasattr(assignment, 'html_url'):
+        print(f"  Canvas URL: {assignment.html_url}")
+    logger.info(f"Created media-recording assignment: '{assignment.name}' (id={assignment.id})")
+
+
+class CanvigatorAssignment:
+    """A Canvas assignment wrapper focused on media-recording check-ins."""
+
+    def __init__(self, canvas, course, canvas_assignment, config):
+        """Capture references and compute an assignment-scoped filename prefix."""
+        self.canvas = canvas
+        self.course = course
+        self.canvas_assignment = canvas_assignment
+        self.config = config
+        self.assignment_prefix = f"assignment{canvas_assignment.id}_"
+
+    def _extractAudioUrl(self, submission):
+        """Return ``(url, ext)`` for an audio/video payload on a submission, or ``(None, None)``.
+
+        Checks ``submission.media_comment`` first (the primary path for
+        media_recording submissions), then falls back to scanning
+        ``submission.attachments`` for any audio/video mime type.
+        """
+        media = getattr(submission, 'media_comment', None)
+        if media:
+            url = media.get('url', '')
+            media_type = media.get('media_type', 'audio')
+            if url:
+                ext = '.m4a' if media_type == 'audio' else '.mp4'
+                return url, ext
+
+        attachments = getattr(submission, 'attachments', None) or []
+        for att in attachments:
+            ct = (att.get('content-type') or att.get('content_type') or '').lower()
+            if not (ct.startswith('audio/') or ct.startswith('video/')):
+                continue
+            url = att.get('url', '')
+            if not url:
+                continue
+            filename = att.get('filename') or att.get('display_name') or ''
+            ext = os.path.splitext(filename)[1] or ('.m4a' if ct.startswith('audio/') else '.mp4')
+            return url, ext
+        return None, None
+
+    def _downloadAudio(self, url, dest_path):
+        """Download an audio/video URL to ``dest_path``. Returns True on success."""
+        try:
+            resp = requests.get(url, timeout=60)
+            resp.raise_for_status()
+            with open(dest_path, 'wb') as f:
+                f.write(resp.content)
+            return True
+        except Exception as e:
+            logger.warning(f"Failed to download {url} -> {dest_path.name}: {e}")
+            return False
+
+    def _buildRecordingRow(self, submission, student_name, audio_path, transcript):
+        """Return a dict with the columns written to the recordings CSV."""
+        return {
+            'student_id': submission.user_id,
+            'student_name': student_name,
+            'submission_id': getattr(submission, 'id', None),
+            'submitted_at': getattr(submission, 'submitted_at', None),
+            'audio_path': audio_path,
+            'transcript': transcript,
+            'transcribed_at': datetime.now(timezone.utc).isoformat(),
+        }
+
+    def _postGrade(self, submission, points_possible, dry_run):
+        """Award full credit on the submission via ``Submission.edit``.
+
+        Returns True if a real grade write succeeded, False on dry-run or failure.
+        """
+        student_id = getattr(submission, 'user_id', '?')
+        if dry_run:
+            logger.info(f"WOULD set grade {points_possible} on submission user_id={student_id}")
+            print(f"     [DRY-RUN] would post grade={points_possible}")
+            return False
+        try:
+            submission.edit(submission={'posted_grade': points_possible})
+            logger.info(f"Posted grade {points_possible} on submission user_id={student_id}")
+            print(f"     Posted grade={points_possible}")
+            return True
+        except Exception as e:
+            logger.warning(f"Grade post failed for user_id={student_id}: {e}")
+            print(f"     ERROR posting grade: {e}")
+            return False
+
+    def getMediaRecordings(self, grade=False, dry_run=False):
+        """Fetch every submission, download audio, transcribe locally, write a CSV.
+
+        With ``grade=True``, also posts ``points_possible`` as the grade for every
+        submitter. ``dry_run=True`` skips the grade write but still downloads and
+        transcribes (downloads are local-only, not Canvas mutations).
+        """
+        student_lookup = {s['id']: s.get('name', '') for s in self.course.students}
+        points_possible = getattr(self.canvas_assignment, 'points_possible', 0) or 0
+
+        media_dir = self.config.data_path / 'media_recordings' / f'assignment{self.canvas_assignment.id}'
+        media_dir.mkdir(parents=True, exist_ok=True)
+
+        client = _make_client(cloud=False)
+        try:
+            client.list()
+        except Exception as e:
+            raise RuntimeError(
+                f"Could not reach Ollama at its configured host ({os.environ.get('OLLAMA_HOST', 'http://localhost:11434')}). "
+                f"Is the Ollama server running? Original error: {e}"
+            ) from e
+        audio_model = DEFAULT_AUDIO_MODEL
+
+        submissions = list(self.canvas_assignment.get_submissions())
+        submitted = [s for s in submissions if getattr(s, 'workflow_state', '') in ('submitted', 'graded')]
+        print(f"\nFound {len(submitted)} submitted recording(s) (of {len(submissions)} total).")
+
+        rows = []
+        n_graded = 0
+        for i, sub in enumerate(submitted, start=1):
+            student_id = getattr(sub, 'user_id', None)
+            student_name = student_lookup.get(student_id, '?')
+            url, ext = self._extractAudioUrl(sub)
+            if not url:
+                logger.info(f"No media payload on submission user_id={student_id}; skipping.")
+                print(f"  [{i}/{len(submitted)}] {student_name} — no media payload, skipping")
+                continue
+
+            local_name = f"{student_id}_{getattr(sub, 'id', 'sub')}{ext}"
+            local_path = media_dir / local_name
+            print(f"  [{i}/{len(submitted)}] {student_name} — downloading...", end="", flush=True)
+            if not self._downloadAudio(url, local_path):
+                print(" FAILED")
+                continue
+            print(" transcribing...", end="", flush=True)
+            transcript = transcribe_audio(str(local_path), client, audio_model)
+            audio_rel = str(local_path.relative_to(self.config.data_path.parent))
+            rows.append(self._buildRecordingRow(sub, student_name, audio_rel, transcript))
+            chars = len(transcript)
+            print(f" done ({chars} chars)")
+
+            if grade:
+                if self._postGrade(sub, points_possible, dry_run):
+                    n_graded += 1
+
+        if not rows:
+            print("\nNo recordings retrieved.")
+            return
+
+        df = pd.DataFrame(rows, columns=[
+            'student_id', 'student_name', 'submission_id',
+            'submitted_at', 'audio_path', 'transcript', 'transcribed_at',
+        ])
+        csv_path = self.config.data_path / f"{self.assignment_prefix}recordings_{today_str()}.csv"
+        df.to_csv(csv_path, index=False)
+        print(f"\nSaved {len(df)} transcript(s) to {csv_path.name}")
+        if grade:
+            verb = "Would have graded" if dry_run else "Graded"
+            print(f"{verb} {n_graded} submission(s) at {points_possible} point(s) each.")
+        logger.info(
+            f"getMediaRecordings: wrote {len(df)} rows to {csv_path} "
+            f"(grade={grade}, dry_run={dry_run}, n_graded={n_graded})"
+        )

--- a/canvigator_assignment.py
+++ b/canvigator_assignment.py
@@ -14,8 +14,15 @@ from datetime import datetime, timezone
 
 import pandas as pd
 
-from canvigator_utils import today_str, selectFromList
-from canvigator_llm import transcribe_audio, _make_client, DEFAULT_AUDIO_MODEL
+from canvigator_utils import today_str, selectFromList, selectCSVFromList, find_latest_csv
+from canvigator_llm import (
+    transcribe_audio,
+    _make_client,
+    DEFAULT_AUDIO_MODEL,
+    DEFAULT_MODEL,
+    analyze_recording_tags,
+    extract_recording_themes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -184,6 +191,79 @@ def createMediaRecordingAssignment(course):
     if hasattr(assignment, 'html_url'):
         print(f"  Canvas URL: {assignment.html_url}")
     logger.info(f"Created media-recording assignment: '{assignment.name}' (id={assignment.id})")
+
+
+def _collectUniqueTags(keywords_series):
+    """Collect a sorted, deduped list of tags from a pandas ``keywords`` column.
+
+    Each cell in ``keywords_series`` is a comma-separated string (or NaN).
+    Tags are lowercased and stripped; duplicates across rows are dropped.
+    """
+    seen = set()
+    tags = []
+    for raw in keywords_series.dropna():
+        for piece in str(raw).split(','):
+            t = piece.strip().lower()
+            if t and t not in seen:
+                seen.add(t)
+                tags.append(t)
+    tags.sort()
+    return tags
+
+
+def _renderAnalysisReport(assignment_name, transcripts_with_names, all_tags, tag_to_indices, themes_md, n_total, n_empty):
+    """Render the recording-analysis Markdown report.
+
+    ``transcripts_with_names`` is a list of (student_name, transcript) tuples for
+    students whose transcripts were non-empty (1-based indices in the report
+    correspond to position in this list). ``tag_to_indices`` maps each tag to a
+    list of 1-based indices into that same list. ``themes_md`` is the LLM's
+    Markdown bullet output.
+    """
+    lines = []
+    lines.append(f"# Media Recording Analysis — {assignment_name}")
+    lines.append("")
+    lines.append(f"_Generated {today_str()} ({len(transcripts_with_names)} transcripts analyzed; "
+                 f"{n_empty} empty / {n_total} total recordings.)_")
+    lines.append("")
+
+    lines.append("## Tag-grounded analysis")
+    lines.append("")
+    lines.append("How often each quiz topic was discussed across the cohort, "
+                 "ranked by number of students who mentioned it (LLM-classified, "
+                 "matched against quiz tags rather than raw substring search).")
+    lines.append("")
+    ranked = sorted(tag_to_indices.items(), key=lambda kv: (-len(kv[1]), kv[0]))
+    nonzero = [(t, idxs) for t, idxs in ranked if idxs]
+    if nonzero:
+        lines.append("| Tag | Students | Names |")
+        lines.append("|---|---:|---|")
+        for tag, idxs in nonzero:
+            names = ", ".join(transcripts_with_names[i - 1][0] for i in idxs)
+            lines.append(f"| {tag} | {len(idxs)} | {names} |")
+    else:
+        lines.append("_(no quiz tags were referenced in any transcript)_")
+    lines.append("")
+    unmentioned = [t for t, idxs in ranked if not idxs]
+    if unmentioned:
+        lines.append(f"_Tags not referenced by anyone ({len(unmentioned)}): "
+                     f"{', '.join(unmentioned)}_")
+        lines.append("")
+
+    lines.append("## LLM-identified themes")
+    lines.append("")
+    lines.append(themes_md or "_(no themes extracted)_")
+    lines.append("")
+
+    lines.append("## Roster")
+    lines.append("")
+    lines.append("Index → student (for resolving the indices in the themes section above).")
+    lines.append("")
+    for i, (name, _t) in enumerate(transcripts_with_names, start=1):
+        lines.append(f"{i}. {name}")
+    lines.append("")
+    lines.append(f"_(Tag list considered: {', '.join(all_tags) if all_tags else '—'})_")
+    return "\n".join(lines)
 
 
 class CanvigatorAssignment:
@@ -364,3 +444,83 @@ class CanvigatorAssignment:
             f"getMediaRecordings: wrote {len(df)} rows to {csv_path} "
             f"(auto_grade={auto_grade}, dry_run={dry_run}, n_graded={n_graded})"
         )
+
+    def analyzeRecordings(self):
+        """Analyze the latest recordings CSV against quiz tags and LLM-extracted themes.
+
+        Loads the most recent ``assignment<id>_recordings_*.csv``, prompts the
+        instructor to pick a ``*_questions_w_tags_*.csv`` from the same course
+        directory, runs a per-transcript classification (gemma4:31b, local) to
+        find which quiz tags each student is actually discussing, then a single
+        cohort-level theme-extraction call. Renders both into one Markdown report.
+        """
+        recordings_csv = find_latest_csv(self.config.data_path, f"{self.assignment_prefix}recordings_")
+        if recordings_csv is None:
+            raise FileNotFoundError(
+                f"No '{self.assignment_prefix}recordings_*.csv' found in {self.config.data_path}. "
+                "Run 'get-media-recordings' first."
+            )
+        print(f"\nUsing recordings file: {recordings_csv.name}")
+
+        tags_csv = selectCSVFromList(
+            self.config.data_path,
+            '_questions_w_tags_',
+            "\nSelect a quiz tags CSV (using index in '[ ]'): ",
+        )
+
+        rec_df = pd.read_csv(recordings_csv)
+        rec_df['transcript'] = rec_df['transcript'].fillna('').astype(str)
+        n_total = len(rec_df)
+        non_empty = rec_df[rec_df['transcript'].str.strip() != '']
+        n_empty = n_total - len(non_empty)
+        if non_empty.empty:
+            print("No non-empty transcripts to analyze.")
+            return
+        transcripts_with_names = [
+            (str(row.get('student_name') or f"id={row.get('student_id')}"), row['transcript'])
+            for _, row in non_empty.iterrows()
+        ]
+
+        tags_df = pd.read_csv(tags_csv)
+        if 'keywords' not in tags_df.columns:
+            raise ValueError(
+                f"'{tags_csv.name}' has no 'keywords' column — was it produced by 'get-quiz-questions --tag'?"
+            )
+        all_tags = _collectUniqueTags(tags_df['keywords'])
+        if not all_tags:
+            raise ValueError(f"No tags found in 'keywords' column of {tags_csv.name}.")
+
+        client = _make_client(cloud=False)
+        try:
+            client.list()
+        except Exception as e:
+            raise RuntimeError(
+                f"Could not reach Ollama at its configured host ({os.environ.get('OLLAMA_HOST', 'http://localhost:11434')}). "
+                f"Is the Ollama server running? Original error: {e}"
+            ) from e
+        model = DEFAULT_MODEL
+
+        print(f"\nAnalyzing {len(transcripts_with_names)} transcript(s) against {len(all_tags)} unique tag(s)...")
+        transcripts_only = [t for _, t in transcripts_with_names]
+
+        def _progress(i, total):
+            print(f"  classified {i}/{total}", end="\r", flush=True)
+        tag_to_indices = analyze_recording_tags(transcripts_only, all_tags, client, model, progress=_progress)
+        print()  # newline after progress
+
+        print("Extracting cohort-level themes...")
+        themes_md = extract_recording_themes(transcripts_only, all_tags, client, model)
+
+        report = _renderAnalysisReport(
+            self.canvas_assignment.name,
+            transcripts_with_names,
+            all_tags,
+            tag_to_indices,
+            themes_md,
+            n_total,
+            n_empty,
+        )
+        out_path = self.config.data_path / f"{self.assignment_prefix}analysis_{today_str()}.md"
+        out_path.write_text(report)
+        print(f"\nSaved analysis to {out_path.name}")
+        logger.info(f"analyzeRecordings: wrote report to {out_path}")

--- a/canvigator_assignment.py
+++ b/canvigator_assignment.py
@@ -9,15 +9,56 @@ instructor can scan a CSV instead of listening to N recordings.
 """
 import logging
 import os
+import subprocess
 from datetime import datetime, timezone
 
 import pandas as pd
-import requests
 
 from canvigator_utils import today_str, selectFromList
 from canvigator_llm import transcribe_audio, _make_client, DEFAULT_AUDIO_MODEL
 
 logger = logging.getLogger(__name__)
+
+# ffmpeg needs https in its protocol whitelist when an input is a DASH/HLS
+# manifest whose fragments are served over https — Canvas (Kaltura/Studio)
+# media-recording playback is delivered as DASH, so without this the demuxer
+# fails with "Protocol 'https' not on whitelist" when loading fragments.
+_FFMPEG_PROTOCOL_WHITELIST = 'file,crypto,data,https,tls,tcp,http,httpproxy'
+
+
+def _fetchAudio(url, audio_path):
+    """Fetch a Canvas media URL and produce a 16 kHz mono PCM WAV at ``audio_path`` via ffmpeg.
+
+    Handles direct media URLs, HLS playlists, and DASH manifests in one pass.
+    The output is always 16 kHz mono PCM WAV — that's the format Ollama's
+    media-detection routes to the audio path on Gemma multimodal models;
+    AAC-in-m4a gets misclassified and rejected as ``image: unknown format``.
+    Returns True on success; False when ffmpeg is missing or the fetch fails
+    (the caller logs and skips).
+    """
+    cmd = [
+        'ffmpeg', '-y', '-loglevel', 'error',
+        '-protocol_whitelist', _FFMPEG_PROTOCOL_WHITELIST,
+        '-i', url,
+        '-vn',
+        '-acodec', 'pcm_s16le',
+        '-ar', '16000',
+        '-ac', '1',
+        str(audio_path),
+    ]
+    try:
+        subprocess.run(cmd, check=True, capture_output=True)
+        return True
+    except FileNotFoundError:
+        logger.warning(
+            "ffmpeg not found in PATH; cannot fetch audio for "
+            f"{audio_path.name}. Install ffmpeg (e.g. 'brew install ffmpeg') to enable."
+        )
+        return False
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr.decode(errors='ignore') if e.stderr else ''
+        logger.warning(f"ffmpeg failed to fetch audio for {audio_path.name}: {stderr[:300]}")
+        return False
 
 
 def _isMediaRecordingAssignment(assignment):
@@ -59,6 +100,37 @@ def _promptYesNo(prompt, default=False):
     if not raw:
         return default
     return raw in ('y', 'yes')
+
+
+def _promptForGrade(student_label, transcript, audio_path, points_possible):
+    """Show a transcript review screen and prompt for the points to award.
+
+    Returns the grade as a float, or ``None`` when the instructor types
+    ``s``/``skip`` to record no grade. Empty input awards ``points_possible``
+    (full credit). Negative or non-numeric input re-prompts.
+    """
+    print("\n" + "-" * 60)
+    print(f"  {student_label}")
+    print("-" * 60)
+    if transcript:
+        print(f"  Transcript:\n    {transcript}")
+    else:
+        print(f"  (transcription empty — listen to {audio_path})")
+    while True:
+        raw = input(f"  Points to award (Enter for {points_possible}, 's' to skip) [{points_possible}]: ").strip()
+        if not raw:
+            return float(points_possible)
+        if raw.lower() in ('s', 'skip'):
+            return None
+        try:
+            value = float(raw)
+        except ValueError:
+            print("  Invalid; please enter a non-negative number, 's' to skip, or Enter for full credit.")
+            continue
+        if value < 0:
+            print("  Invalid; please enter a non-negative number, 's' to skip, or Enter for full credit.")
+            continue
+        return value
 
 
 def createMediaRecordingAssignment(course):
@@ -153,20 +225,13 @@ class CanvigatorAssignment:
             return url, ext
         return None, None
 
-    def _downloadAudio(self, url, dest_path):
-        """Download an audio/video URL to ``dest_path``. Returns True on success."""
-        try:
-            resp = requests.get(url, timeout=60)
-            resp.raise_for_status()
-            with open(dest_path, 'wb') as f:
-                f.write(resp.content)
-            return True
-        except Exception as e:
-            logger.warning(f"Failed to download {url} -> {dest_path.name}: {e}")
-            return False
+    def _buildRecordingRow(self, submission, student_name, audio_path, transcript, grade=None):
+        """Return a dict with the columns written to the recordings CSV.
 
-    def _buildRecordingRow(self, submission, student_name, audio_path, transcript):
-        """Return a dict with the columns written to the recordings CSV."""
+        ``grade`` is the points awarded (float) or ``None`` when no grade was
+        recorded for this row. ``graded_at`` is set to the current UTC ISO
+        timestamp when ``grade`` is not None, otherwise empty.
+        """
         return {
             'student_id': submission.user_id,
             'student_name': student_name,
@@ -175,34 +240,55 @@ class CanvigatorAssignment:
             'audio_path': audio_path,
             'transcript': transcript,
             'transcribed_at': datetime.now(timezone.utc).isoformat(),
+            'grade': '' if grade is None else grade,
+            'graded_at': datetime.now(timezone.utc).isoformat() if grade is not None else '',
         }
 
-    def _postGrade(self, submission, points_possible, dry_run):
-        """Award full credit on the submission via ``Submission.edit``.
+    def _postGrade(self, submission, points, dry_run):
+        """Post ``points`` on the submission via ``Submission.edit``.
 
         Returns True if a real grade write succeeded, False on dry-run or failure.
         """
         student_id = getattr(submission, 'user_id', '?')
         if dry_run:
-            logger.info(f"WOULD set grade {points_possible} on submission user_id={student_id}")
-            print(f"     [DRY-RUN] would post grade={points_possible}")
+            logger.info(f"WOULD set grade {points} on submission user_id={student_id}")
+            print(f"     [DRY-RUN] would post grade={points}")
             return False
         try:
-            submission.edit(submission={'posted_grade': points_possible})
-            logger.info(f"Posted grade {points_possible} on submission user_id={student_id}")
-            print(f"     Posted grade={points_possible}")
+            submission.edit(submission={'posted_grade': points})
+            logger.info(f"Posted grade {points} on submission user_id={student_id}")
+            print(f"     Posted grade={points}")
             return True
         except Exception as e:
             logger.warning(f"Grade post failed for user_id={student_id}: {e}")
             print(f"     ERROR posting grade: {e}")
             return False
 
-    def getMediaRecordings(self, grade=False, dry_run=False):
-        """Fetch every submission, download audio, transcribe locally, write a CSV.
+    def _writeRecordingsCsv(self, rows):
+        """Write the recordings CSV with the canonical column order."""
+        df = pd.DataFrame(rows, columns=[
+            'student_id', 'student_name', 'submission_id',
+            'submitted_at', 'audio_path', 'transcript', 'transcribed_at',
+            'grade', 'graded_at',
+        ])
+        csv_path = self.config.data_path / f"{self.assignment_prefix}recordings_{today_str()}.csv"
+        df.to_csv(csv_path, index=False)
+        return csv_path, df
 
-        With ``grade=True``, also posts ``points_possible`` as the grade for every
-        submitter. ``dry_run=True`` skips the grade write but still downloads and
-        transcribes (downloads are local-only, not Canvas mutations).
+    def getMediaRecordings(self, auto_grade=False, dry_run=False):
+        """Fetch every submission, transcribe locally, optionally review and grade interactively.
+
+        For each submitter, ffmpeg pulls the media URL directly (handling DASH
+        manifests, HLS playlists, and direct media URLs uniformly) and writes
+        a 16 kHz mono PCM WAV to ``data/<course>/media_recordings/assignment<id>/``.
+        The local audio model transcribes that file.
+
+        Default: after each transcription, the transcript is displayed and the
+        instructor is prompted for the points to award. Enter awards full credit;
+        a number overrides; ``s``/``skip`` records no grade. With
+        ``auto_grade=True``, the per-student display and prompt are suppressed
+        and ``points_possible`` is awarded automatically. ``dry_run=True`` skips
+        Canvas writes on either path; the CSV is still written.
         """
         student_lookup = {s['id']: s.get('name', '') for s in self.course.students}
         points_possible = getattr(self.canvas_assignment, 'points_possible', 0) or 0
@@ -226,47 +312,55 @@ class CanvigatorAssignment:
 
         rows = []
         n_graded = 0
-        for i, sub in enumerate(submitted, start=1):
-            student_id = getattr(sub, 'user_id', None)
-            student_name = student_lookup.get(student_id, '?')
-            url, ext = self._extractAudioUrl(sub)
-            if not url:
-                logger.info(f"No media payload on submission user_id={student_id}; skipping.")
-                print(f"  [{i}/{len(submitted)}] {student_name} — no media payload, skipping")
-                continue
+        try:
+            for i, sub in enumerate(submitted, start=1):
+                student_id = getattr(sub, 'user_id', None)
+                student_name = student_lookup.get(student_id, '?')
+                url, _ext = self._extractAudioUrl(sub)
+                if not url:
+                    logger.info(f"No media payload on submission user_id={student_id}; skipping.")
+                    print(f"  [{i}/{len(submitted)}] {student_name} — no media payload, skipping")
+                    continue
 
-            local_name = f"{student_id}_{getattr(sub, 'id', 'sub')}{ext}"
-            local_path = media_dir / local_name
-            print(f"  [{i}/{len(submitted)}] {student_name} — downloading...", end="", flush=True)
-            if not self._downloadAudio(url, local_path):
-                print(" FAILED")
-                continue
-            print(" transcribing...", end="", flush=True)
-            transcript = transcribe_audio(str(local_path), client, audio_model)
-            audio_rel = str(local_path.relative_to(self.config.data_path.parent))
-            rows.append(self._buildRecordingRow(sub, student_name, audio_rel, transcript))
-            chars = len(transcript)
-            print(f" done ({chars} chars)")
+                local_path = media_dir / f"{student_id}_{getattr(sub, 'id', 'sub')}.wav"
+                audio_rel = str(local_path.relative_to(self.config.data_path.parent))
+                print(f"  [{i}/{len(submitted)}] {student_name} — fetching audio...", end="", flush=True)
+                if not _fetchAudio(url, local_path):
+                    print(" FAILED")
+                    rows.append(self._buildRecordingRow(sub, student_name, audio_rel, ""))
+                    continue
+                print(" transcribing...", end="", flush=True)
+                transcript = transcribe_audio(str(local_path), client, audio_model)
+                chars = len(transcript)
+                print(f" done ({chars} chars)")
 
-            if grade:
-                if self._postGrade(sub, points_possible, dry_run):
-                    n_graded += 1
+                if auto_grade:
+                    grade_value = float(points_possible)
+                else:
+                    student_label = student_name if student_name and student_name != '?' else f"id={student_id}"
+                    grade_value = _promptForGrade(student_label, transcript, audio_rel, points_possible)
+
+                if grade_value is not None:
+                    if self._postGrade(sub, grade_value, dry_run):
+                        n_graded += 1
+                rows.append(self._buildRecordingRow(sub, student_name, audio_rel, transcript, grade_value))
+        except KeyboardInterrupt:
+            print("\nInterrupted — flushing partial CSV before exiting.")
+            if rows:
+                csv_path, _ = self._writeRecordingsCsv(rows)
+                print(f"Saved {len(rows)} partial row(s) to {csv_path.name}")
+            raise
 
         if not rows:
             print("\nNo recordings retrieved.")
             return
 
-        df = pd.DataFrame(rows, columns=[
-            'student_id', 'student_name', 'submission_id',
-            'submitted_at', 'audio_path', 'transcript', 'transcribed_at',
-        ])
-        csv_path = self.config.data_path / f"{self.assignment_prefix}recordings_{today_str()}.csv"
-        df.to_csv(csv_path, index=False)
+        csv_path, df = self._writeRecordingsCsv(rows)
         print(f"\nSaved {len(df)} transcript(s) to {csv_path.name}")
-        if grade:
+        if n_graded:
             verb = "Would have graded" if dry_run else "Graded"
-            print(f"{verb} {n_graded} submission(s) at {points_possible} point(s) each.")
+            print(f"{verb} {n_graded} submission(s).")
         logger.info(
             f"getMediaRecordings: wrote {len(df)} rows to {csv_path} "
-            f"(grade={grade}, dry_run={dry_run}, n_graded={n_graded})"
+            f"(auto_grade={auto_grade}, dry_run={dry_run}, n_graded={n_graded})"
         )

--- a/canvigator_llm.py
+++ b/canvigator_llm.py
@@ -214,6 +214,11 @@ _ASSESSMENT_GUIDE_SYSTEM_PROMPT = (
 
 def _strip_html(text):
     """Reduce Canvas HTML question text to plain text suitable for prompting."""
+    # pd.read_csv returns NaN (a float) for empty cells — bool(NaN) is True so the
+    # `not text` check below isn't sufficient on its own. Coerce non-strings to ""
+    # up front so callers can pass row.get('question_text') without checking.
+    if not isinstance(text, str):
+        return ""
     if not text:
         return ""
 
@@ -1339,32 +1344,47 @@ def generate_open_ended_questions(rows, model=None, n=3, progress=None):
     frame = 0
     for i, row in enumerate(rows, start=1):
         label = row.get('question_name') or row.get('question_id')
+        if not isinstance(label, str):
+            label = str(label) if label is not None else '?'
         if spin_fn:
             spin_fn(frame, f"[{i}/{total}] {label} — classifying")
             frame += 1
         else:
             print(f"  [{i}/{total}] {label} — classifying...", end="", flush=True)
-        mode = classify_question_mode(row, client, model)
-        if spin_fn:
-            spin_fn(frame, f"[{i}/{total}] {label} — {mode} — generating {n} candidates")
-            frame += 1
-        else:
-            print(f" {mode} — generating {n} candidates...", end="", flush=True)
-        candidates = generate_open_ended_candidates(row, client, model, mode, n=n)
-        non_empty = len([c for c in candidates if c])
-        if spin_fn:
-            spin_fn(frame, f"[{i}/{total}] {label} — writing {non_empty} guide(s) + rubric(s) + exemplars")
-            frame += 1
-        else:
-            print(f" writing {non_empty} guide(s) + rubric(s) + exemplars...", end="", flush=True)
-        guides = [generate_assessment_guide(row, client, model, mode, cand) for cand in candidates]
-        rubrics = [generate_structured_rubric(row, client, model, mode, cand) for cand in candidates]
-        exemplars = [generate_exemplars(row, client, model, mode, cand, rub) for cand, rub in zip(candidates, rubrics)]
-        if not spin_fn:
-            print(" done")
-
-        if not candidates:
-            logger.warning(f"No candidates generated for question {row.get('question_id')}")
+        # Wrap the per-question LLM pipeline so any single failure (NaN inputs,
+        # transient API errors, etc.) doesn't kill the whole run — emit empty
+        # placeholder rows for the failed question and move on. The padding logic
+        # below handles missing candidates/guides/rubrics/exemplars uniformly.
+        try:
+            mode = classify_question_mode(row, client, model)
+            if spin_fn:
+                spin_fn(frame, f"[{i}/{total}] {label} — {mode} — generating {n} candidates")
+                frame += 1
+            else:
+                print(f" {mode} — generating {n} candidates...", end="", flush=True)
+            candidates = generate_open_ended_candidates(row, client, model, mode, n=n)
+            non_empty = len([c for c in candidates if c])
+            if spin_fn:
+                spin_fn(frame, f"[{i}/{total}] {label} — writing {non_empty} guide(s) + rubric(s) + exemplars")
+                frame += 1
+            else:
+                print(f" writing {non_empty} guide(s) + rubric(s) + exemplars...", end="", flush=True)
+            guides = [generate_assessment_guide(row, client, model, mode, cand) for cand in candidates]
+            rubrics = [generate_structured_rubric(row, client, model, mode, cand) for cand in candidates]
+            exemplars = [generate_exemplars(row, client, model, mode, cand, rub) for cand, rub in zip(candidates, rubrics)]
+            if not spin_fn:
+                print(" done")
+            if not candidates:
+                logger.warning(f"No candidates generated for question {row.get('question_id')}")
+        except Exception as e:
+            logger.warning(f"Question {row.get('question_id')} failed and was skipped: {e}")
+            if not spin_fn:
+                print(f" SKIPPED ({e})")
+            mode = ''
+            candidates = []
+            guides = []
+            rubrics = []
+            exemplars = []
 
         # Always emit exactly n rows per question so every group has a predictable shape.
         padded_candidates = (candidates + [''] * n)[:n]
@@ -1394,3 +1414,144 @@ def generate_open_ended_questions(rows, model=None, n=3, progress=None):
     else:
         print("Generation complete.")
     return results
+
+
+# -----------------------------------------------------------------------------
+# Recording analysis (used by analyze-media-recordings)
+# -----------------------------------------------------------------------------
+
+_RECORDING_CLASSIFY_SYSTEM_PROMPT = (
+    "You are an instructor reviewing a student's brief check-in recording. The student "
+    "was asked to discuss a topic from a recent quiz. Their speech is often informal, "
+    "rambling, or incomplete. Your job: identify which of the provided quiz topics the "
+    "student is actually discussing.\n\n"
+    "RULES:\n"
+    "- Choose ONLY from the provided list of topics. Do not invent new tags.\n"
+    "- Match on meaning, not exact words — a student saying 'I got confused on the "
+    "linked list one' counts as discussing 'linked lists'.\n"
+    "- Return matched topics as a comma-separated list on a single line, lowercase.\n"
+    "- If the student is clearly off-topic or the transcript is too vague to map to "
+    "any topic, respond with the single word 'none'.\n"
+    "- Do not include explanations, preamble, or numbering — just the comma-separated "
+    "tags or 'none'."
+)
+
+_RECORDING_THEMES_SYSTEM_PROMPT = (
+    "You are an instructor analyzing a small set of student check-in recordings to "
+    "find recurring themes. The students were asked to discuss a topic from a recent "
+    "quiz; transcripts are often informal and meandering. The quiz topics are provided "
+    "as context — themes you identify may align with those topics, or may surface "
+    "concerns that don't map to any single topic (study habits, confidence, pacing, "
+    "specific examples that confused them, etc.).\n\n"
+    "Identify 3-5 distinct themes that appear across multiple students. For each theme:\n"
+    "- A short title (3-6 words, in bold).\n"
+    "- One sentence describing what students are saying.\n"
+    "- A list of student indices (1-based) who raised this theme.\n\n"
+    "Format your response as Markdown bullets. Do not include preamble, headers, or a "
+    "summary — just the themed bullets, one per theme. If fewer than 3 distinct themes "
+    "are evident, return only what is genuinely present."
+)
+
+
+def _build_classify_recording_prompt(transcript, tags):
+    """Build the user-side prompt for classifying a single transcript against a tag list."""
+    parts = []
+    parts.append(f"Quiz topics (choose only from this list): {', '.join(tags)}")
+    parts.append(f"Student transcript: {transcript}")
+    parts.append("Topics this student is discussing (comma-separated, or 'none'):")
+    return "\n".join(parts)
+
+
+def _parse_classify_response(response, valid_tags):
+    """Parse a classify response into a list of tags drawn from ``valid_tags``.
+
+    Tags are matched case-insensitively against ``valid_tags`` so the LLM can't
+    smuggle in a tag that wasn't on the list. ``'none'`` returns an empty list.
+    """
+    if not response:
+        return []
+    line = response.strip().splitlines()[0].strip().strip(".").lower()
+    if not line or line == "none":
+        return []
+    valid_lower = {t.lower(): t for t in valid_tags}
+    out = []
+    seen = set()
+    for raw in line.split(","):
+        candidate = raw.strip().strip("\"'")
+        if not candidate or candidate == "none":
+            continue
+        canonical = valid_lower.get(candidate)
+        if canonical and canonical not in seen:
+            seen.add(canonical)
+            out.append(canonical)
+    return out
+
+
+def _build_themes_prompt(transcripts, tags):
+    """Build the user-side prompt for cohort-level theme extraction.
+
+    ``transcripts`` is a list of strings (already filtered to non-empty); the
+    1-based index of each appears in the prompt so the LLM can refer to students
+    as ``Student 1``, ``Student 2``, etc.
+    """
+    parts = [f"Quiz topics (for context): {', '.join(tags)}", "", "Transcripts:"]
+    for i, t in enumerate(transcripts, start=1):
+        parts.append(f"Student {i}: {t}")
+    parts.append("")
+    parts.append("Recurring themes across these students (Markdown bullets):")
+    return "\n".join(parts)
+
+
+def analyze_recording_tags(transcripts, tags, client, model, progress=None):
+    """Run a per-transcript LLM classification against ``tags``.
+
+    ``transcripts`` is a list of strings. Returns a dict mapping each tag (the
+    canonical form from the input ``tags`` list) to a list of 1-based transcript
+    indices that mention it. Tags that no transcript mentions are still included
+    with an empty list, so the caller can render a complete table.
+
+    ``progress`` is an optional callable invoked as ``progress(i, total)`` after
+    each transcript so the caller can update a spinner.
+    """
+    tag_to_indices = {t: [] for t in tags}
+    total = len(transcripts)
+    for i, transcript in enumerate(transcripts, start=1):
+        prompt = _build_classify_recording_prompt(transcript, tags)
+        try:
+            resp = _chat_with_retry(
+                client,
+                model=model,
+                messages=[
+                    {"role": "system", "content": _RECORDING_CLASSIFY_SYSTEM_PROMPT},
+                    {"role": "user", "content": prompt},
+                ],
+                options={"temperature": 0.1},
+            )
+            matched = _parse_classify_response(resp["message"]["content"], tags)
+        except Exception as e:
+            logger.warning(f"Recording classify failed for transcript {i}: {e}")
+            matched = []
+        for tag in matched:
+            tag_to_indices[tag].append(i)
+        if progress:
+            progress(i, total)
+    return tag_to_indices
+
+
+def extract_recording_themes(transcripts, tags, client, model):
+    """Single-call cohort-level theme extraction. Returns a Markdown bullet list as a string."""
+    prompt = _build_themes_prompt(transcripts, tags)
+    try:
+        resp = _chat_with_retry(
+            client,
+            model=model,
+            messages=[
+                {"role": "system", "content": _RECORDING_THEMES_SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+            options={"temperature": 0.3},
+        )
+        return resp["message"]["content"].strip()
+    except Exception as e:
+        logger.warning(f"Recording themes extraction failed: {e}")
+        return f"_(theme extraction failed: {e})_"

--- a/test_canvigator.py
+++ b/test_canvigator.py
@@ -1,5 +1,6 @@
 """Tests for canvigator utility functions and core algorithms."""
 import hashlib
+import subprocess
 import pytest
 import pandas as pd
 from datetime import datetime
@@ -2497,17 +2498,28 @@ class TestCanvigatorAssignment:
         assert ca._extractAudioUrl(sub) == (None, None)
 
     def test_build_recording_row_shape(self):
-        """_buildRecordingRow returns a dict with all expected columns populated."""
+        """_buildRecordingRow returns a dict with all expected columns populated; grade defaults to empty."""
         ca = self._make_instance()
         sub = SimpleNamespace(user_id=42, id=7, submitted_at='2026-05-01T12:00:00Z')
-        row = ca._buildRecordingRow(sub, 'Alice', 'data/course/media_recordings/assignment999/42_7.m4a', 'hello')
+        row = ca._buildRecordingRow(sub, 'Alice', 'data/course/media_recordings/assignment999/42_7.wav', 'hello')
         assert row['student_id'] == 42
         assert row['student_name'] == 'Alice'
         assert row['submission_id'] == 7
         assert row['submitted_at'] == '2026-05-01T12:00:00Z'
-        assert row['audio_path'] == 'data/course/media_recordings/assignment999/42_7.m4a'
+        assert row['audio_path'] == 'data/course/media_recordings/assignment999/42_7.wav'
         assert row['transcript'] == 'hello'
         assert 'transcribed_at' in row and row['transcribed_at']
+        # Default grade=None yields empty grade and graded_at columns.
+        assert row['grade'] == ''
+        assert row['graded_at'] == ''
+
+    def test_build_recording_row_records_grade_and_graded_at(self):
+        """When a grade is passed, _buildRecordingRow records the value and a graded_at timestamp."""
+        ca = self._make_instance()
+        sub = SimpleNamespace(user_id=42, id=7, submitted_at='2026-05-01T12:00:00Z')
+        row = ca._buildRecordingRow(sub, 'Alice', 'audio.wav', 'hello', grade=0.5)
+        assert row['grade'] == 0.5
+        assert row['graded_at']  # non-empty ISO timestamp
 
     def test_post_grade_dry_run_does_not_call_edit(self):
         """In dry-run mode, _postGrade skips Submission.edit and returns False."""
@@ -2538,3 +2550,80 @@ class TestCanvigatorAssignment:
             result = ca._postGrade(sub, 2, dry_run=False)
         assert result is False
         assert any('Grade post failed' in r.message for r in caplog.records)
+
+    def test_fetch_audio_invokes_ffmpeg_with_url_and_whitelist(self):
+        """_fetchAudio passes the URL directly to ffmpeg with an https-capable protocol whitelist."""
+        from canvigator_assignment import _fetchAudio
+        audio = Path('/tmp/data/course/media_recordings/assignment999/42_7.wav')
+        with patch('canvigator_assignment.subprocess.run') as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode=0)
+            result = _fetchAudio('https://canvas/manifest.mpd', audio)
+        assert result is True
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == 'ffmpeg'
+        assert '-protocol_whitelist' in cmd
+        whitelist = cmd[cmd.index('-protocol_whitelist') + 1]
+        # https must be allowed so ffmpeg can follow DASH/HLS fragment URLs.
+        assert 'https' in whitelist
+        # Input URL is passed directly, not a local file.
+        assert 'https://canvas/manifest.mpd' in cmd
+        # Output is audio-only PCM WAV at 16 kHz mono — the format Gemma's
+        # audio path accepts. Anything else (e.g. AAC m4a) gets rejected as
+        # "image: unknown format" by Ollama's media-type detector.
+        assert '-vn' in cmd
+        assert 'pcm_s16le' in cmd
+        assert cmd[cmd.index('-ar') + 1] == '16000'
+        assert cmd[cmd.index('-ac') + 1] == '1'
+        assert str(audio) in cmd
+
+    def test_fetch_audio_handles_missing_ffmpeg(self, caplog):
+        """When ffmpeg is not on PATH, _fetchAudio returns False and logs a warning."""
+        import logging as _logging
+        from canvigator_assignment import _fetchAudio
+        audio = Path('/tmp/missing/v.m4a')
+        with patch('canvigator_assignment.subprocess.run', side_effect=FileNotFoundError()):
+            with caplog.at_level(_logging.WARNING, logger='canvigator_assignment'):
+                result = _fetchAudio('https://x/y', audio)
+        assert result is False
+        assert any('ffmpeg not found' in r.message for r in caplog.records)
+
+    def test_fetch_audio_handles_ffmpeg_failure(self, caplog):
+        """When ffmpeg exits non-zero, _fetchAudio returns False and logs a warning."""
+        import logging as _logging
+        from canvigator_assignment import _fetchAudio
+        audio = Path('/tmp/v.m4a')
+        err = subprocess.CalledProcessError(1, 'ffmpeg', stderr=b'bad input')
+        with patch('canvigator_assignment.subprocess.run', side_effect=err):
+            with caplog.at_level(_logging.WARNING, logger='canvigator_assignment'):
+                result = _fetchAudio('https://x/y', audio)
+        assert result is False
+        assert any('ffmpeg failed' in r.message for r in caplog.records)
+
+    def test_prompt_for_grade_returns_full_credit_on_empty(self, monkeypatch):
+        """Empty input on the prompt awards points_possible (full credit)."""
+        from canvigator_assignment import _promptForGrade
+        monkeypatch.setattr('builtins.input', lambda _prompt='': '')
+        result = _promptForGrade('Alice', 'transcript text', 'audio.wav', points_possible=1)
+        assert result == 1.0
+
+    def test_prompt_for_grade_returns_none_on_skip(self, monkeypatch):
+        """'s', 'skip' (case-insensitive) record no grade for the student."""
+        from canvigator_assignment import _promptForGrade
+        for raw in ('s', 'S', 'skip', 'SKIP'):
+            monkeypatch.setattr('builtins.input', lambda _prompt='', _raw=raw: _raw)
+            assert _promptForGrade('Alice', 'transcript', 'audio.wav', points_possible=1) is None
+
+    def test_prompt_for_grade_returns_numeric_value(self, monkeypatch):
+        """A numeric value is returned as a float, even when smaller or larger than points_possible."""
+        from canvigator_assignment import _promptForGrade
+        monkeypatch.setattr('builtins.input', lambda _prompt='': '0.5')
+        assert _promptForGrade('Alice', 't', 'a.wav', points_possible=1) == 0.5
+        monkeypatch.setattr('builtins.input', lambda _prompt='': '2')
+        assert _promptForGrade('Alice', 't', 'a.wav', points_possible=1) == 2.0
+
+    def test_prompt_for_grade_reprompts_on_invalid(self, monkeypatch):
+        """Negative and non-numeric input re-prompt; the eventual valid input is returned."""
+        from canvigator_assignment import _promptForGrade
+        inputs = iter(['-1', 'oops', '1'])
+        monkeypatch.setattr('builtins.input', lambda _prompt='': next(inputs))
+        assert _promptForGrade('Alice', 't', 'a.wav', points_possible=1) == 1.0

--- a/test_canvigator.py
+++ b/test_canvigator.py
@@ -653,6 +653,19 @@ class TestStripHtml:
         from canvigator_llm import _strip_html
         assert _strip_html("a    b   c") == "a b c"
 
+    def test_handles_nan_and_other_non_strings(self):
+        """Non-string inputs (NaN, ints, lists) yield empty string instead of crashing.
+
+        pd.read_csv returns NaN (a float) for empty cells; bool(NaN) is True so
+        the historical `if not text` check let NaN through to the regex, which
+        crashed with 'expected string or bytes-like object, got float'.
+        """
+        from canvigator_llm import _strip_html
+        assert _strip_html(float('nan')) == ""
+        assert _strip_html(0) == ""
+        assert _strip_html(123) == ""
+        assert _strip_html([]) == ""
+
 
 class TestParseTags:
     """Tests for _parse_tags response parser."""
@@ -922,6 +935,60 @@ class TestBuildOpenEndedPrompt:
         from canvigator_llm import _build_open_ended_prompt
         result = _build_open_ended_prompt("", "", None, "explain")
         assert "Oral explanation question" in result
+
+
+class TestGenerateOpenEndedQuestionsRecovery:
+    """generate_open_ended_questions must survive a per-row LLM failure with partial output."""
+
+    def test_one_failing_row_does_not_kill_the_loop(self):
+        """A row that raises mid-pipeline yields placeholder rows; other rows succeed normally."""
+        import canvigator_llm
+        rows = [
+            {'question_id': 1, 'question_name': 'Q1', 'question_text': '<p>Q1</p>', 'keywords': 'a', 'position': 1, 'answers': '[]'},
+            {'question_id': 2, 'question_name': float('nan'), 'question_text': float('nan'), 'keywords': 'b', 'position': 2, 'answers': '[]'},
+            {'question_id': 3, 'question_name': 'Q3', 'question_text': '<p>Q3</p>', 'keywords': 'c', 'position': 3, 'answers': '[]'},
+        ]
+
+        def fake_classify(row, _client, _model):
+            # Simulate a transient API failure on the bad row.
+            if row.get('question_id') == 2:
+                raise RuntimeError("simulated API error on question 2")
+            return 'explain'
+
+        def fake_candidates(_row, _client, _model, _mode, n=3):
+            return [f'candidate {i + 1}' for i in range(n)]
+
+        def fake_guide(_row, _client, _model, _mode, _cand):
+            return 'guide'
+
+        def fake_rubric(_row, _client, _model, _mode, _cand):
+            return canvigator_llm._empty_rubric('explain')
+
+        def fake_exemplars(_row, _client, _model, _mode, _cand, _rub):
+            return dict(canvigator_llm._EMPTY_EXEMPLARS)
+
+        with patch.object(canvigator_llm, '_make_client', return_value=MagicMock()), \
+             patch.object(canvigator_llm, 'classify_question_mode', side_effect=fake_classify), \
+             patch.object(canvigator_llm, 'generate_open_ended_candidates', side_effect=fake_candidates), \
+             patch.object(canvigator_llm, 'generate_assessment_guide', side_effect=fake_guide), \
+             patch.object(canvigator_llm, 'generate_structured_rubric', side_effect=fake_rubric), \
+             patch.object(canvigator_llm, 'generate_exemplars', side_effect=fake_exemplars):
+            results = canvigator_llm.generate_open_ended_questions(rows, n=3)
+
+        # 3 questions × 3 candidates = 9 rows total, regardless of failure.
+        assert len(results) == 9
+        # Q1 and Q3 produce real candidates.
+        for qid in (1, 3):
+            qrows = [r for r in results if r['question_id'] == qid]
+            assert all(r['open_ended_question'].startswith('candidate') for r in qrows)
+            assert all(r['question_mode'] == 'explain' for r in qrows)
+        # Q2 produces 3 placeholder rows: empty open_ended_question, empty mode.
+        q2_rows = [r for r in results if r['question_id'] == 2]
+        assert len(q2_rows) == 3
+        assert all(r['open_ended_question'] == '' for r in q2_rows)
+        assert all(r['question_mode'] == '' for r in q2_rows)
+        # NaN question_text is coerced to empty string by _strip_html, not a crash.
+        assert all(r['original_question_text'] == '' for r in q2_rows)
 
 
 # ---------------------------------------------------------------------------
@@ -2627,3 +2694,80 @@ class TestCanvigatorAssignment:
         inputs = iter(['-1', 'oops', '1'])
         monkeypatch.setattr('builtins.input', lambda _prompt='': next(inputs))
         assert _promptForGrade('Alice', 't', 'a.wav', points_possible=1) == 1.0
+
+    def test_collect_unique_tags_lowercases_and_dedupes(self):
+        """_collectUniqueTags collapses duplicates across rows, lowercases, and sorts."""
+        from canvigator_assignment import _collectUniqueTags
+        series = pd.Series([
+            'graphs, recursion, hash tables',
+            'Hash Tables, big-o',
+            'graphs',
+            None,
+            '   ',
+        ])
+        assert _collectUniqueTags(series) == ['big-o', 'graphs', 'hash tables', 'recursion']
+
+    def test_render_analysis_report_orders_tags_by_count(self):
+        """Tag-grounded analysis section ranks tags by descending student count."""
+        from canvigator_assignment import _renderAnalysisReport
+        transcripts = [('Alice', 'a'), ('Bob', 'b'), ('Carol', 'c')]
+        tag_to_indices = {
+            'graphs': [1, 2],
+            'recursion': [1, 2, 3],
+            'big-o': [],
+        }
+        report = _renderAnalysisReport(
+            'Quiz 1 Check-in', transcripts, ['big-o', 'graphs', 'recursion'],
+            tag_to_indices, '- **Confusion**: ...', 5, 2,
+        )
+        # 'recursion' appears before 'graphs' (3 > 2 students); 'big-o' is reported as unmentioned.
+        assert report.index('| recursion |') < report.index('| graphs |')
+        assert 'Tags not referenced by anyone' in report
+        assert 'big-o' in report.split('Tags not referenced by anyone')[1]
+        # Roster section lists each student with their 1-based index.
+        assert '\n1. Alice' in report
+        assert '\n3. Carol' in report
+        # Coverage line surfaces the total/empty counts.
+        assert '3 transcripts analyzed' in report
+        assert '2 empty' in report
+
+
+class TestRecordingAnalysisLLM:
+    """Tests for the recording-analysis prompt builders and parsers in canvigator_llm."""
+
+    def test_classify_response_filters_to_valid_tags(self):
+        """_parse_classify_response only keeps tags that appear in the valid list."""
+        from canvigator_llm import _parse_classify_response
+        valid = ['graphs', 'recursion', 'hash tables']
+        assert _parse_classify_response('graphs, recursion', valid) == ['graphs', 'recursion']
+        # Invented tag is dropped; valid tags are preserved.
+        assert _parse_classify_response('graphs, dynamic programming', valid) == ['graphs']
+        # Case-insensitive match canonicalizes back to the valid form.
+        assert _parse_classify_response('Graphs, RECURSION', valid) == ['graphs', 'recursion']
+
+    def test_classify_response_handles_none(self):
+        """A 'none' response yields an empty list."""
+        from canvigator_llm import _parse_classify_response
+        assert _parse_classify_response('none', ['graphs']) == []
+        assert _parse_classify_response('  None.  ', ['graphs']) == []
+        assert _parse_classify_response('', ['graphs']) == []
+
+    def test_classify_response_dedupes(self):
+        """Duplicate tags in the response are emitted once."""
+        from canvigator_llm import _parse_classify_response
+        assert _parse_classify_response('graphs, graphs, GRAPHS', ['graphs']) == ['graphs']
+
+    def test_build_classify_prompt_includes_tags_and_transcript(self):
+        """The classify prompt embeds both the tag list and the transcript verbatim."""
+        from canvigator_llm import _build_classify_recording_prompt
+        prompt = _build_classify_recording_prompt('I struggled with graphs', ['graphs', 'recursion'])
+        assert 'graphs, recursion' in prompt
+        assert 'I struggled with graphs' in prompt
+
+    def test_build_themes_prompt_numbers_students(self):
+        """The themes prompt labels each transcript with a 1-based 'Student N:' index."""
+        from canvigator_llm import _build_themes_prompt
+        prompt = _build_themes_prompt(['first', 'second'], ['graphs'])
+        assert 'Student 1: first' in prompt
+        assert 'Student 2: second' in prompt
+        assert 'graphs' in prompt

--- a/test_canvigator.py
+++ b/test_canvigator.py
@@ -4,7 +4,8 @@ import pytest
 import pandas as pd
 from datetime import datetime
 from pathlib import Path
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 
 # ---------------------------------------------------------------------------
@@ -2414,3 +2415,126 @@ class TestSendAllQuizRemindersFiltering:
         assert any("Skipping 'Quiz Z'" in r.message for r in caplog.records)
         # No reminder-worthy state, so we hit the "all caught up" branch
         assert 'All students are caught up' in captured
+
+
+# ---------------------------------------------------------------------------
+# canvigator_assignment tests
+# ---------------------------------------------------------------------------
+
+class TestCanvigatorAssignment:
+    """Tests for canvigator_assignment helpers and class methods."""
+
+    def _make_assignment_obj(self, points_possible=1):
+        """Build a minimal stand-in for a Canvas Assignment object."""
+        return SimpleNamespace(id=999, points_possible=points_possible)
+
+    def _make_instance(self, points_possible=1):
+        """Build a CanvigatorAssignment with mocked dependencies."""
+        from canvigator_assignment import CanvigatorAssignment
+        return CanvigatorAssignment(
+            canvas=MagicMock(),
+            course=MagicMock(),
+            canvas_assignment=self._make_assignment_obj(points_possible),
+            config=MagicMock(),
+        )
+
+    def test_is_media_recording_assignment_filter(self):
+        """Filter passes only assignments whose submission_types is exactly ['media_recording']."""
+        from canvigator_assignment import _isMediaRecordingAssignment
+        assert _isMediaRecordingAssignment(SimpleNamespace(submission_types=['media_recording'])) is True
+        assert _isMediaRecordingAssignment(SimpleNamespace(submission_types=['online_text_entry'])) is False
+        # Mixed types must NOT match — we want recording-only assignments.
+        assert _isMediaRecordingAssignment(SimpleNamespace(submission_types=['media_recording', 'online_upload'])) is False
+        assert _isMediaRecordingAssignment(SimpleNamespace(submission_types=None)) is False
+        assert _isMediaRecordingAssignment(SimpleNamespace(submission_types=[])) is False
+
+    def test_extract_audio_url_from_media_comment(self):
+        """media_comment with an audio media_type yields a .m4a extension."""
+        ca = self._make_instance()
+        sub = SimpleNamespace(media_comment={'url': 'https://canvas/audio.m4a', 'media_type': 'audio'})
+        url, ext = ca._extractAudioUrl(sub)
+        assert url == 'https://canvas/audio.m4a'
+        assert ext == '.m4a'
+
+    def test_extract_audio_url_video_media_comment_uses_mp4(self):
+        """A video media_comment yields an .mp4 extension instead of .m4a."""
+        ca = self._make_instance()
+        sub = SimpleNamespace(media_comment={'url': 'https://canvas/v.mp4', 'media_type': 'video'})
+        url, ext = ca._extractAudioUrl(sub)
+        assert url == 'https://canvas/v.mp4'
+        assert ext == '.mp4'
+
+    def test_extract_audio_url_from_attachment_fallback(self):
+        """When no media_comment is present, audio attachments are picked up by mime type."""
+        ca = self._make_instance()
+        sub = SimpleNamespace(
+            media_comment=None,
+            attachments=[{
+                'url': 'https://canvas/file.webm',
+                'filename': 'recording.webm',
+                'content-type': 'audio/webm',
+            }],
+        )
+        url, ext = ca._extractAudioUrl(sub)
+        assert url == 'https://canvas/file.webm'
+        assert ext == '.webm'
+
+    def test_extract_audio_url_returns_none_when_empty(self):
+        """A submission with neither media_comment nor attachments returns (None, None)."""
+        ca = self._make_instance()
+        sub = SimpleNamespace(media_comment=None, attachments=[])
+        assert ca._extractAudioUrl(sub) == (None, None)
+
+    def test_extract_audio_url_skips_non_audio_attachments(self):
+        """Non-audio attachments (e.g. PDFs) are ignored."""
+        ca = self._make_instance()
+        sub = SimpleNamespace(
+            media_comment=None,
+            attachments=[
+                {'url': 'https://canvas/notes.pdf', 'filename': 'notes.pdf', 'content-type': 'application/pdf'},
+            ],
+        )
+        assert ca._extractAudioUrl(sub) == (None, None)
+
+    def test_build_recording_row_shape(self):
+        """_buildRecordingRow returns a dict with all expected columns populated."""
+        ca = self._make_instance()
+        sub = SimpleNamespace(user_id=42, id=7, submitted_at='2026-05-01T12:00:00Z')
+        row = ca._buildRecordingRow(sub, 'Alice', 'data/course/media_recordings/assignment999/42_7.m4a', 'hello')
+        assert row['student_id'] == 42
+        assert row['student_name'] == 'Alice'
+        assert row['submission_id'] == 7
+        assert row['submitted_at'] == '2026-05-01T12:00:00Z'
+        assert row['audio_path'] == 'data/course/media_recordings/assignment999/42_7.m4a'
+        assert row['transcript'] == 'hello'
+        assert 'transcribed_at' in row and row['transcribed_at']
+
+    def test_post_grade_dry_run_does_not_call_edit(self):
+        """In dry-run mode, _postGrade skips Submission.edit and returns False."""
+        ca = self._make_instance(points_possible=3)
+        sub = MagicMock()
+        sub.user_id = 42
+        result = ca._postGrade(sub, 3, dry_run=True)
+        assert result is False
+        sub.edit.assert_not_called()
+
+    def test_post_grade_real_call_uses_points_possible(self):
+        """A real grade post calls Submission.edit with posted_grade=points_possible."""
+        ca = self._make_instance(points_possible=5)
+        sub = MagicMock()
+        sub.user_id = 42
+        result = ca._postGrade(sub, 5, dry_run=False)
+        assert result is True
+        sub.edit.assert_called_once_with(submission={'posted_grade': 5})
+
+    def test_post_grade_logs_warning_on_failure(self, caplog):
+        """When Submission.edit raises, _postGrade logs a warning and returns False."""
+        import logging as _logging
+        ca = self._make_instance(points_possible=2)
+        sub = MagicMock()
+        sub.user_id = 42
+        sub.edit.side_effect = RuntimeError("Canvas down")
+        with caplog.at_level(_logging.WARNING, logger='canvigator_assignment'):
+            result = ca._postGrade(sub, 2, dry_run=False)
+        assert result is False
+        assert any('Grade post failed' in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Three commits add a complete media-recording check-in workflow: instructors create a Canvas assignment that accepts only audio/video recordings, fetch + transcribe submissions locally, review and grade each interactively, and run an LLM analysis over the cohort's transcripts.

- **Five new CLI tasks** in a new "Media Recording Check-Ins" group: `create-media-recording-assignment`, `get-media-recordings`, and `analyze-media-recordings`.
- **Two new flags**: `--auto-grade`/`-g` (skip the per-student review prompt and stamp full credit) and `--dry-run`/`-d` now also covers `get-media-recordings` (skips Canvas writes; CSV is still written).
- **New module** `canvigator_assignment.py` (526 lines) wraps a Canvas Assignment with `CanvigatorAssignment`. Pure helpers: `_isMediaRecordingAssignment`, `_selectMediaRecordingAssignment`, `_fetchAudio`, `_promptForGrade`, `_collectUniqueTags`, `_renderAnalysisReport`, `_extractAudioUrl`, `_buildRecordingRow`, `_postGrade`.
- **New LLM helpers** in `canvigator_llm.py`: `analyze_recording_tags` (per-transcript tag classification, paraphrase-tolerant) and `extract_recording_themes` (cohort-level Markdown). All routed through the local `gemma4:31b` (`cloud=False`) — student transcripts never leave the machine.
- **Privacy**: every student-data path uses the local Ollama daemon. Audio transcription via `gemma4:e4b`, analysis via `gemma4:31b`. Cloud-hosted models are reserved for instructor-side text generation that doesn't see student input.
- **Robustness**:
  - ffmpeg URL-direct fetch with `-protocol_whitelist file,crypto,data,https,tls,tcp,http,httpproxy` so Canvas's DASH/Kaltura playback URLs resolve in one pass.
  - 16 kHz mono PCM WAV output — the format Ollama's media-detection routes to the audio path on Gemma multimodal models (AAC m4a is misclassified as image).
  - `KeyboardInterrupt` mid-`get-media-recordings` flushes a partial CSV before re-raising so review progress isn't lost.
  - `_strip_html` now coerces NaN/non-strings to `""` (prior `if not text` check let NaN through to `re.sub`); `generate_open_ended_questions` wraps each per-question pipeline so a single failed row emits placeholder rows and continues, instead of killing the whole run.

## Commits in this PR

1. `fcbcd74` — Add media-recording check-in assignment tasks (initial `create-media-recording-assignment` + `get-media-recordings`).
2. `6244965` — Add interactive grading + DASH/audio-format fixes (rename `--grade` → `--auto-grade`, default flow shows transcript and prompts for points; ffmpeg URL-direct + WAV output).
3. `ae7b408` — Add `analyze-media-recordings` + harden NaN handling in LLM helpers.

## Test plan

- [x] `flake8` (both CI commands, E9/F63/F7/F82 + complexity 15 + line length 160) clean
- [x] `python -m pytest test_canvigator.py` — 221/221 pass (+27 vs main: 18 for `TestCanvigatorAssignment`, 7 for `TestRecordingAnalysisLLM`, 2 for the NaN-recovery cases)
- [x] Manual smoke against a sandbox Canvas course:
  - [x] `create-media-recording-assignment` creates an unpublished assignment with `submission_types=['media_recording']` and the prompt body as HTML description
  - [x] `get-media-recordings` (default) shows transcript inline, prompts for points, posts grade to Canvas
  - [x] `get-media-recordings -g` (auto-grade) skips prompt, stamps full credit
  - [x] `get-media-recordings -d -g` previews grade writes only — no Canvas mutation
  - [x] DASH manifest from Canvas resolved by ffmpeg; transcript non-empty in output CSV
  - [x] `analyze-media-recordings` writes `assignment<id>_analysis_YYYYMMDD.md` with the tag-ranked table + LLM themes + roster

## Out of scope

- Audio playback from inside the tool (instructor can `open <audio_path>` manually)
- Bulk pre-set "everyone gets X points" at startup (use `--auto-grade` instead, or live with Enter-for-full)
- Re-grading via a second pass over an existing CSV
- An `--all`-style multi-assignment retrieval (single-assignment is the intended unit — one check-in per class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)